### PR TITLE
Remove cache.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -37,26 +37,21 @@ internal class KotlinAnnotationIntrospector(
     //       it can be passed a null to default it
     //       this likely impacts this class to be accurate about what COULD be considered required
 
-    override fun hasRequiredMarker(m: AnnotatedMember): Boolean? {
-        val hasRequired = cache.javaMemberIsRequired(m) {
-            try {
-                when {
-                    nullToEmptyCollection && m.type.isCollectionLikeType -> false
-                    nullToEmptyMap && m.type.isMapLikeType -> false
-                    else -> m.member.declaringClass.toKmClass()?.let {
-                        when (m) {
-                            is AnnotatedField -> m.hasRequiredMarker(it)
-                            is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it)
-                            is AnnotatedParameter -> m.hasRequiredMarker(it)
-                            else -> null
-                        }
-                    }
+    override fun hasRequiredMarker(m: AnnotatedMember): Boolean? = try {
+        when {
+            nullToEmptyCollection && m.type.isCollectionLikeType -> false
+            nullToEmptyMap && m.type.isMapLikeType -> false
+            else -> m.member.declaringClass.toKmClass()?.let {
+                when (m) {
+                    is AnnotatedField -> m.hasRequiredMarker(it)
+                    is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it)
+                    is AnnotatedParameter -> m.hasRequiredMarker(it)
+                    else -> null
                 }
-            } catch (ex: UnsupportedOperationException) {
-                null
             }
         }
-        return hasRequired
+    } catch (ex: UnsupportedOperationException) {
+        null
     }
 
     // Find a serializer to handle the case where the getter returns an unboxed value from the value class.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -27,10 +27,8 @@ import java.lang.reflect.Method
 
 internal class KotlinAnnotationIntrospector(
     private val context: Module.SetupContext,
-    private val cache: ReflectionCache,
     private val nullToEmptyCollection: Boolean,
-    private val nullToEmptyMap: Boolean,
-    private val nullIsSameAsDefault: Boolean
+    private val nullToEmptyMap: Boolean
 ) : NopAnnotationIntrospector() {
 
     // TODO: implement nullIsSameAsDefault flag, which represents when TRUE that if something has a default value,

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -71,9 +71,9 @@ public class KotlinModule private constructor(
         }
 
         context.insertAnnotationIntrospector(
-            KotlinAnnotationIntrospector(context, cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault)
+            KotlinAnnotationIntrospector(context, nullToEmptyCollection, nullToEmptyMap)
         )
-        context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(this, cache))
+        context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(this))
 
         context.addDeserializers(KotlinDeserializers())
         context.addKeyDeserializers(KotlinKeyDeserializers)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -24,10 +24,7 @@ import java.lang.reflect.Executable
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
-internal class KotlinNamesAnnotationIntrospector constructor(
-    val module: KotlinModule,
-    val cache: ReflectionCache
-) : NopAnnotationIntrospector() {
+internal class KotlinNamesAnnotationIntrospector(val module: KotlinModule) : NopAnnotationIntrospector() {
     // since 2.4
     override fun findImplicitPropertyName(
         member: AnnotatedMember

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -1,7 +1,6 @@
 package com.fasterxml.jackson.module.kotlin
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.introspect.AnnotatedWithParams
 import com.fasterxml.jackson.databind.util.LRUMap
@@ -12,29 +11,8 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
 internal class ReflectionCache(reflectionCacheSize: Int) {
-    sealed class BooleanTriState(val value: Boolean?) {
-        class True : BooleanTriState(true)
-        class False : BooleanTriState(false)
-        class Empty : BooleanTriState(null)
-
-        companion object {
-            private val TRUE = True()
-            private val FALSE = False()
-            private val EMPTY = Empty()
-
-            fun fromBoolean(value: Boolean?): BooleanTriState {
-                return when (value) {
-                    null -> EMPTY
-                    true -> TRUE
-                    false -> FALSE
-                }
-            }
-        }
-    }
-
-    private val javaConstructorToValueCreator = LRUMap<Constructor<Any>, ConstructorValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
+    private val javaConstructorToValueCreator = LRUMap<Constructor<*>, ConstructorValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
     private val javaMethodToValueCreator = LRUMap<Method, MethodValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
-    private val javaMemberIsRequired = LRUMap<AnnotatedMember, BooleanTriState?>(reflectionCacheSize, reflectionCacheSize)
 
     /**
      * return null if...
@@ -42,10 +20,9 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
      * - contains extensionReceiverParameter
      * - instance parameter is not companion object or can't get
      */
-    @Suppress("UNCHECKED_CAST")
-    fun valueCreatorFromJava(_withArgsCreator: AnnotatedWithParams): ValueCreator<*>? = when (_withArgsCreator) {
+    fun valueCreatorFromJava(withArgsCreator: AnnotatedWithParams): ValueCreator<*> = when (withArgsCreator) {
         is AnnotatedConstructor -> {
-            val constructor = _withArgsCreator.annotated as Constructor<Any>
+            val constructor = withArgsCreator.annotated
 
             javaConstructorToValueCreator.get(constructor)
                 ?: run {
@@ -54,7 +31,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
                 }
         }
         is AnnotatedMethod -> {
-            val method = _withArgsCreator.annotated as Method
+            val method = withArgsCreator.annotated as Method
 
             javaMethodToValueCreator.get(method)
                 ?: kotlin.run {
@@ -62,9 +39,6 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
                     javaMethodToValueCreator.putIfAbsent(method, value) ?: value
                 }
         }
-        else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${_withArgsCreator.annotated.javaClass.name}")
+        else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${withArgsCreator.annotated.javaClass.name}")
     } // we cannot reflect this method so do the default Java-ish behavior
-
-    fun javaMemberIsRequired(key: AnnotatedMember, calc: (AnnotatedMember) -> Boolean?): Boolean? = javaMemberIsRequired.get(key)?.value
-        ?: calc(key).let { javaMemberIsRequired.putIfAbsent(key, BooleanTriState.fromBoolean(it))?.value ?: it }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -11,15 +11,11 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
 internal class ReflectionCache(reflectionCacheSize: Int) {
-    private val javaConstructorToValueCreator = LRUMap<Constructor<*>, ConstructorValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
-    private val javaMethodToValueCreator = LRUMap<Method, MethodValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
+    private val javaConstructorToValueCreator =
+        LRUMap<Constructor<*>, ConstructorValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
+    private val javaMethodToValueCreator =
+        LRUMap<Method, MethodValueCreator<*>>(reflectionCacheSize, reflectionCacheSize)
 
-    /**
-     * return null if...
-     * - can't get kotlinFunction
-     * - contains extensionReceiverParameter
-     * - instance parameter is not companion object or can't get
-     */
     fun valueCreatorFromJava(withArgsCreator: AnnotatedWithParams): ValueCreator<*> = when (withArgsCreator) {
         is AnnotatedConstructor -> {
             val constructor = withArgsCreator.annotated
@@ -39,6 +35,9 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
                     javaMethodToValueCreator.putIfAbsent(method, value) ?: value
                 }
         }
-        else -> throw IllegalStateException("Expected a constructor or method to create a Kotlin object, instead found ${withArgsCreator.annotated.javaClass.name}")
+        else -> throw IllegalStateException(
+            "Expected a constructor or method to create a Kotlin object," +
+                " instead found ${withArgsCreator.annotated.javaClass.name}"
+        )
     } // we cannot reflect this method so do the default Java-ish behavior
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/KotlinValueInstantiator.kt
@@ -62,7 +62,6 @@ internal class KotlinValueInstantiator(
         buffer: PropertyValueBuffer
     ): Any? {
         val valueCreator: ValueCreator<*> = cache.valueCreatorFromJava(_withArgsCreator)
-            ?: return super.createFromObjectWith(ctxt, props, buffer)
 
         val bucket = valueCreator.generateBucket()
 


### PR DESCRIPTION
Benchmarking showed that performance did not change much when the cache was turned off.
Therefore, reduced the cache.

I also tried caching the process related to `AnnotationIntrospector`, but this did not have a significant effect either.