### PR TITLE
Fix error during initialization by Spring's Jackson2ObjectMapperBuilder.

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.21" />
+  </component>
+</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,6 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:2.14.1")
 
     // test libs
-    testImplementation(kotlin("reflect"))
-
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("io.mockk:mockk:1.13.3")

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinFeature.kt
@@ -5,7 +5,7 @@ import java.util.BitSet
 /**
  * @see KotlinModule.Builder
  */
-public enum class KotlinFeature(private val enabledByDefault: Boolean) {
+public enum class KotlinFeature(internal val enabledByDefault: Boolean) {
     /**
      * This feature represents whether to deserialize `null` values for collection properties as empty collections.
      */

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -30,13 +30,15 @@ import java.util.*
  *                                      (e.g. List<String>) may contain null values after deserialization.  Enabling it
  *                                      protects against this but has significant performance impact.
  */
+// Do not delete default arguments,
+// as this will cause an error during initialization by Spring's Jackson2ObjectMapperBuilder.
 public class KotlinModule private constructor(
-    public val reflectionCacheSize: Int,
-    public val nullToEmptyCollection: Boolean,
-    public val nullToEmptyMap: Boolean,
-    public val nullIsSameAsDefault: Boolean,
-    public val singletonSupport: Boolean,
-    public val strictNullChecks: Boolean
+    public val reflectionCacheSize: Int = Builder.reflectionCacheSizeDefault,
+    public val nullToEmptyCollection: Boolean = NullToEmptyCollection.enabledByDefault,
+    public val nullToEmptyMap: Boolean = NullToEmptyMap.enabledByDefault,
+    public val nullIsSameAsDefault: Boolean = NullIsSameAsDefault.enabledByDefault,
+    public val singletonSupport: Boolean = SingletonSupport.enabledByDefault,
+    public val strictNullChecks: Boolean = StrictNullChecks.enabledByDefault
 ) : SimpleModule(KotlinModule::class.java.name /* TODO: add Version parameter */) {
     private constructor(builder: Builder) : this(
         builder.reflectionCacheSize,
@@ -85,7 +87,11 @@ public class KotlinModule private constructor(
     }
 
     public class Builder {
-        public var reflectionCacheSize: Int = 512
+        public companion object {
+            internal const val reflectionCacheSizeDefault = 512
+        }
+
+        public var reflectionCacheSize: Int = reflectionCacheSizeDefault
             private set
 
         private val bitSet: BitSet = KotlinFeature.defaults

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/Github46.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/Github46.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import kotlin.reflect.full.primaryConstructor
 
 class TestGithub46 {
     @Test
@@ -23,19 +22,6 @@ class TestGithub46 {
 
         // then
         assertEquals(json, rejson)
-    }
-
-    @Test fun byReflectionDo32() {
-        val constructor = TestData::class.primaryConstructor!!
-        val data = constructor.callBy(
-            constructor.parameters.map {
-                it to true
-            }.toMap()
-        )
-        assertEquals(
-            TestData(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true),
-            data
-        )
     }
 
     data class TestData(


### PR DESCRIPTION
Because it was assumed that it could be initialized with no arguments.