### PR TITLE
Partial support value class deserialization.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -64,7 +64,14 @@ internal val defaultConstructorMarker: Class<*> by lazy {
 internal fun String.reconstructClass(): Class<*> = Class.forName(this.replace(".", "$").replace("/", "."))
 
 internal fun KmClass.findKmConstructor(constructor: Constructor<*>): KmConstructor? {
+    val descHead = constructor.parameterTypes.toDescString()
+    val desc = descHead + "V"
+    // Only constructors that take a value class as an argument have a DefaultConstructorMarker on the Signature.
+    val valueDesc = descHead.dropLast(1) + "Lkotlin/jvm/internal/DefaultConstructorMarker;)V"
+
     // Constructors always have the same name, so only desc is compared
-    val desc = constructor.parameterTypes.toDescString() + "V"
-    return constructors.find { it.signature?.desc == desc }
+    return constructors.find {
+        val targetDesc = it.signature?.desc
+        targetDesc == desc || targetDesc == valueDesc
+    }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/ValueClassUnboxConverter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/ValueClassUnboxConverter.kt
@@ -1,0 +1,17 @@
+package com.fasterxml.jackson.module.kotlin.deser
+
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.type.TypeFactory
+import com.fasterxml.jackson.databind.util.Converter
+
+internal class ValueClassUnboxConverter<T>(private val valueClass: Class<T>) : Converter<T, Any?> {
+    private val unboxMethod = valueClass.getDeclaredMethod("unbox-impl").apply {
+        if (!this.isAccessible) this.isAccessible = true
+    }
+    private val outType = unboxMethod.returnType
+
+    override fun convert(value: T): Any? = unboxMethod.invoke(value)
+
+    override fun getInputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(valueClass)
+    override fun getOutputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(outType)
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ValueParameter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ValueParameter.kt
@@ -25,6 +25,7 @@ internal class ValueParameter(private val param: KmValueParameter) {
     }
 
     val name: String = param.name
+    val type: KmType = param.type
     val isOptional: Boolean = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(param.flags)
     val isPrimitive: Boolean = Flag.IS_PRIVATE(param.type.flags)
     val isNullable: Boolean = Flag.Type.IS_NULLABLE(param.type.flags)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/value_class/default_argument/ConstructorTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/value_class/default_argument/ConstructorTest.kt
@@ -1,0 +1,28 @@
+package com.fasterxml.jackson.module.kotlin._integration.deser.value_class.default_argument
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ConstructorTest {
+    data class Dst(val uInt: UInt = UInt.MAX_VALUE)
+
+    @Test
+    fun withDefault() {
+        val mapper = jacksonObjectMapper()
+        val result = mapper.readValue<Dst>("{}")
+        assertEquals(Dst(), result)
+    }
+
+    @Test
+    fun withoutDefault() {
+        val mapper = jacksonObjectMapper()
+
+        val value = (Int.MAX_VALUE.toLong() + 1).toUInt()
+        val src = mapper.writeValueAsString(Dst(value))
+
+        val result = mapper.readValue<Dst>(src)
+        assertEquals(Dst(value), result)
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/value_class/default_argument/FactoryTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/value_class/default_argument/FactoryTest.kt
@@ -1,0 +1,35 @@
+package com.fasterxml.jackson.module.kotlin._integration.deser.value_class.default_argument
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class FactoryTest {
+    data class Dst(val uInt: UInt) {
+        companion object {
+            @JvmStatic
+            @JsonCreator
+            fun creator(uInt: UInt = UInt.MAX_VALUE): Dst = Dst(uInt)
+        }
+    }
+
+    @Test
+    fun withDefault() {
+        val mapper = jacksonObjectMapper()
+        val result = mapper.readValue<Dst>("{}")
+        Assertions.assertEquals(Dst.creator(), result)
+    }
+
+    @Test
+    fun withoutDefault() {
+        val mapper = jacksonObjectMapper()
+
+        val value = (Int.MAX_VALUE.toLong() + 1).toUInt()
+        val src = mapper.writeValueAsString(Dst(value))
+
+        val result = mapper.readValue<Dst>(src)
+        Assertions.assertEquals(Dst(value), result)
+    }
+}


### PR DESCRIPTION
Fixed deserialization of functions with `value class` arguments to work.
It is assumed that deserialization of the `value class` will work, at least if it was registered a `Deserializer` with `ObjectMapper`.

However, the following known deficiencies exist at this PR

- The `JsonDeserialize` annotation does not work.
- `JsonCreator` annotation given in `value class` does not work

