### PR TITLE
Improve `value class` serialize support

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -1,8 +1,10 @@
 package com.fasterxml.jackson.module.kotlin
 
+import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
@@ -82,3 +84,5 @@ internal fun KmClass.findPropertyByGetter(getter: Method): KmProperty? {
     val signature = getter.toSignature()
     return properties.find { it.getterSignature == signature }
 }
+
+internal fun KmType.isNullable(): Boolean = Flag.Type.IS_NULLABLE(this.flags)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinAnnotationIntrospector.kt
@@ -64,7 +64,7 @@ internal class KotlinAnnotationIntrospector(
         val fieldSignature = member.toSignature()
         val byNullability = kmClass.properties
             .find { it.fieldSignature == fieldSignature }
-            ?.let { !Flag.Type.IS_NULLABLE(it.returnType.flags) }
+            ?.let { !it.returnType.isNullable() }
 
         return requiredAnnotationOrNullability(byAnnotation, byNullability)
     }
@@ -80,7 +80,7 @@ internal class KotlinAnnotationIntrospector(
         else -> byAnnotation
     }
 
-    private fun KmProperty.isRequiredByNullability(): Boolean = !Flag.Type.IS_NULLABLE(this.returnType.flags)
+    private fun KmProperty.isRequiredByNullability(): Boolean = !this.returnType.isNullable()
 
     private fun AnnotatedMethod.getRequiredMarkerFromCorrespondingAccessor(kmClass: KmClass): Boolean? {
         val memberSignature = member.toSignature()
@@ -116,7 +116,7 @@ internal class KotlinAnnotationIntrospector(
         }?.let { (paramDef, paramType) ->
             val isPrimitive = paramType.isPrimitive
             val isOptional = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(paramDef.flags)
-            val isMarkedNullable = Flag.Type.IS_NULLABLE(paramDef.type.flags)
+            val isMarkedNullable = paramDef.type.isNullable()
 
             !isMarkedNullable && !isOptional &&
                 !(isPrimitive && !context.isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES))

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinNamesAnnotationIntrospector.kt
@@ -133,6 +133,7 @@ internal class KotlinNamesAnnotationIntrospector(
         val getter = a.member.apply {
             // If the return value of the getter is a value class,
             // it will be serialized properly without doing anything.
+            // TODO: Verify the case where a value class encompasses another value class.
             if (this.returnType.isUnboxableValueClass()) return null
         }
         val kotlinProperty = cache.getKmClass(getter.declaringClass)?.findPropertyByGetter(getter)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ValueParameter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ValueParameter.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator
 
+import com.fasterxml.jackson.module.kotlin.isNullable
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
@@ -17,7 +18,7 @@ internal class ValueParameter(private val param: KmValueParameter) {
         }
 
         class ArgumentImpl(type: KmType) : Argument {
-            override val isNullable: Boolean = Flag.Type.IS_NULLABLE(type.flags)
+            override val isNullable: Boolean = type.isNullable()
 
             // TODO: Formatting because it is a minimal display about the error content
             override val name: String = type.classifier.toString()
@@ -28,7 +29,7 @@ internal class ValueParameter(private val param: KmValueParameter) {
     val type: KmType = param.type
     val isOptional: Boolean = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(param.flags)
     val isPrimitive: Boolean = Flag.IS_PRIVATE(param.type.flags)
-    val isNullable: Boolean = Flag.Type.IS_NULLABLE(param.type.flags)
+    val isNullable: Boolean = type.isNullable()
     val isGenericType: Boolean = param.type.classifier is KmClassifier.TypeParameter
 
     val arguments: List<Argument> by lazy {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
@@ -1,0 +1,17 @@
+package com.fasterxml.jackson.module.kotlin.ser
+
+import com.fasterxml.jackson.databind.util.StdConverter
+
+// S is nullable because value corresponds to a nullable value class
+// @see KotlinNamesAnnotationIntrospector.findNullSerializer
+internal class ValueClassBoxConverter<S : Any?, D : Any>(
+    unboxedClass: Class<S>,
+    valueClass: Class<D>
+) : StdConverter<S, D>() {
+    private val boxMethod = valueClass.getDeclaredMethod("box-impl", unboxedClass).apply {
+        if (!this.isAccessible) this.isAccessible = true
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: S): D = boxMethod.invoke(null, value) as D
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/ValueClasses.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/ValueClasses.kt
@@ -1,0 +1,32 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+
+@JvmInline
+value class Primitive(val v: Int) {
+    class Serializer : StdSerializer<Primitive>(Primitive::class.java) {
+        override fun serialize(value: Primitive, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeNumber(value.v)
+        }
+    }
+}
+
+@JvmInline
+value class NonNullObject(val v: String) {
+    class Serializer : StdSerializer<NonNullObject>(NonNullObject::class.java) {
+        override fun serialize(value: NonNullObject, gen: JsonGenerator, provider: SerializerProvider) {
+            gen.writeString(value.v)
+        }
+    }
+}
+
+@JvmInline
+value class NullableObject(val v: String?) {
+    class Serializer : StdSerializer<NullableObject>(NullableObject::class.java) {
+        override fun serialize(value: NullableObject, gen: JsonGenerator, provider: SerializerProvider) {
+            value.v?.let { gen.writeString(it) } ?: gen.writeNull()
+        }
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
@@ -1,0 +1,73 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.by_annotation.non_null_object
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.NonNullObject
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.testPrettyWriter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ByAnnotationTest {
+    companion object {
+        val writer = jacksonObjectMapper().testPrettyWriter()
+    }
+
+    data class NonNullSrc(
+        @get:JsonSerialize(using = NonNullObject.Serializer::class)
+        val getterAnn: NonNullObject,
+        @field:JsonSerialize(using = NonNullObject.Serializer::class)
+        val fieldAnn: NonNullObject
+    )
+
+    @Test
+    fun nonNull() {
+        val src = NonNullSrc(NonNullObject("foo"), NonNullObject("bar"))
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : "foo",
+                  "fieldAnn" : "bar"
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    data class NullableSrc(
+        @get:JsonSerialize(using = NonNullObject.Serializer::class)
+        val getterAnn: NonNullObject?,
+        @field:JsonSerialize(using = NonNullObject.Serializer::class)
+        val fieldAnn: NonNullObject?
+    )
+
+    @Test
+    fun nullableWithoutNull() {
+        val src = NullableSrc(NonNullObject("foo"), NonNullObject("bar"))
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : "foo",
+                  "fieldAnn" : "bar"
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    @Test
+    fun nullableWithNull() {
+        val src = NullableSrc(null, null)
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : null,
+                  "fieldAnn" : null
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
@@ -57,10 +57,10 @@ class ByAnnotationTest {
     }
 
     @Test
-    fun failing() {
+    fun nullableWithNull() {
         val src = NullableSrc(null, null)
 
-        Assertions.assertNotEquals(
+        Assertions.assertEquals(
             """
                 {
                   "getterAnn" : null,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
@@ -57,10 +57,10 @@ class ByAnnotationTest {
     }
 
     @Test
-    fun nullableWithNull() {
+    fun failing() {
         val src = NullableSrc(null, null)
 
-        Assertions.assertEquals(
+        Assertions.assertNotEquals(
             """
                 {
                   "getterAnn" : null,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NonNullValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NonNullValueTest.kt
@@ -1,0 +1,73 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.by_annotation.nullable_object.by_annotation
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.NullableObject
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.testPrettyWriter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class NonNullValueTest {
+    companion object {
+        val writer = jacksonObjectMapper().testPrettyWriter()
+    }
+
+    data class NonNullSrc(
+        @get:JsonSerialize(using = NullableObject.Serializer::class)
+        val getterAnn: NullableObject,
+        @field:JsonSerialize(using = NullableObject.Serializer::class)
+        val fieldAnn: NullableObject
+    )
+
+    @Test
+    fun nonNull() {
+        val src = NonNullSrc(NullableObject("foo"), NullableObject("bar"))
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : "foo",
+                  "fieldAnn" : "bar"
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    data class NullableSrc(
+        @get:JsonSerialize(using = NullableObject.Serializer::class)
+        val getterAnn: NullableObject?,
+        @field:JsonSerialize(using = NullableObject.Serializer::class)
+        val fieldAnn: NullableObject?
+    )
+
+    @Test
+    fun nullableWithoutNull() {
+        val src = NullableSrc(NullableObject("foo"), NullableObject("bar"))
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : "foo",
+                  "fieldAnn" : "bar"
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    @Test
+    fun nullableWithNull() {
+        val src = NullableSrc(null, null)
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : null,
+                  "fieldAnn" : null
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NullValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NullValueTest.kt
@@ -20,10 +20,10 @@ class NullValueTest {
     )
 
     @Test
-    fun nonNull() {
+    fun failing() {
         val src = NonNullSrc(NullableObject(null), NullableObject(null))
 
-        Assertions.assertEquals(
+        Assertions.assertNotEquals(
             """
                 {
                   "getterAnn" : null,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NullValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NullValueTest.kt
@@ -1,0 +1,73 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.by_annotation.nullable_object.by_annotation
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.NullableObject
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.testPrettyWriter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class NullValueTest {
+    companion object {
+        val writer = jacksonObjectMapper().testPrettyWriter()
+    }
+
+    data class NonNullSrc(
+        @get:JsonSerialize(using = NullableObject.Serializer::class)
+        val getterAnn: NullableObject,
+        @field:JsonSerialize(using = NullableObject.Serializer::class)
+        val fieldAnn: NullableObject
+    )
+
+    @Test
+    fun nonNull() {
+        val src = NonNullSrc(NullableObject(null), NullableObject(null))
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : null,
+                  "fieldAnn" : null
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    data class NullableSrc(
+        @get:JsonSerialize(using = NullableObject.Serializer::class)
+        val getterAnn: NullableObject?,
+        @field:JsonSerialize(using = NullableObject.Serializer::class)
+        val fieldAnn: NullableObject?
+    )
+
+    @Test
+    fun nullableWithoutNull() {
+        val src = NullableSrc(NullableObject(null), NullableObject(null))
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : null,
+                  "fieldAnn" : null
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    @Test
+    fun nullableWithNull() {
+        val src = NullableSrc(null, null)
+
+        Assertions.assertEquals(
+            """
+                {
+                  "getterAnn" : null,
+                  "fieldAnn" : null
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/primitive/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/primitive/ByAnnotationTest.kt
@@ -1,0 +1,97 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.by_annotation.primitive
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializer.Primitive
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.testPrettyWriter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class ByAnnotationTest {
+    companion object {
+        val writer = jacksonObjectMapper().testPrettyWriter()
+    }
+
+    data class NonNullSrc(
+        @get:JsonSerialize(using = Primitive.Serializer::class)
+        val getterAnn: Primitive,
+        @field:JsonSerialize(using = Primitive.Serializer::class)
+        val fieldAnn: Primitive
+    )
+
+    @Test
+    fun nonNull() {
+        val src = NonNullSrc(Primitive(0), Primitive(1))
+
+        assertEquals(
+            """
+                {
+                  "getterAnn" : 0,
+                  "fieldAnn" : 1
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    data class NullableSrc(
+        @get:JsonSerialize(using = Primitive.Serializer::class)
+        val getterAnn: Primitive?,
+        @field:JsonSerialize(using = Primitive.Serializer::class)
+        val fieldAnn: Primitive?
+    )
+
+    @Test
+    fun nullableWithoutNull() {
+        val src = NullableSrc(Primitive(0), Primitive(1))
+
+        assertEquals(
+            """
+                {
+                  "getterAnn" : 0,
+                  "fieldAnn" : 1
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    @Test
+    fun nullableWithNull() {
+        val src = NullableSrc(null, null)
+
+        assertEquals(
+            """
+                {
+                  "getterAnn" : null,
+                  "fieldAnn" : null
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+
+    data class Failing(
+        @JsonSerialize(using = Primitive.Serializer::class)
+        val nonNull: Primitive,
+        @JsonSerialize(using = Primitive.Serializer::class)
+        val nullable: Primitive?
+    )
+
+    // #46
+    @Test
+    fun failing() {
+        val src = Failing(Primitive(0), Primitive(1))
+
+        assertNotEquals(
+            """
+                {
+                  "nonNull" : 0,
+                  "nullable" : 1
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/GitHub524.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/GitHub524.kt
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 
 // Most of the current behavior has been tested on GitHub464, so only serializer-related behavior is tested here.
@@ -61,12 +60,12 @@ class GitHub524 {
 
     class SerializeByAnnotation(@get:JsonSerialize(using = Serializer::class) val foo: HasSerializer = HasSerializer(1))
 
+    // fixed at d56e7189e24828f03cfba9ddd665da55d89bf01e
     @Test
-    fun failing() {
-        val writer = jacksonObjectMapper().writerWithDefaultPrettyPrinter()
+    fun fixed() {
+        val writer = jacksonObjectMapper().testPrettyWriter()
 
-        // JsonSerialize is not working now.
-        assertNotEquals(
+        assertEquals(
             """
                 {
                   "foo" : "HasSerializer(value=1)"


### PR DESCRIPTION
Fixed #38 except in the following cases

- #46 if applicable
- If the unboxed value is `null` (the `value` of the `value class` is `nullable` and the property is `non-null`).