### PR TITLE
Fixed to basically `unbox` when serializing `value class`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ If you find any problems, it would be appreciated if you could share them in an 
 Currently this project is in `alpha`.  
 After the following features are implemented, this project will be moved to the `beta` version if there is enough demand for it.
 
-- Change serialization behavior of `value class`.
-  - ~~Basically, it should not be `unboxed`, but should behave like a normal class.~~ [#37](https://github.com/ProjectMapK/jackson-module-kogera/pull/37)
 - Deserialization support for `value class
   - Partial support is achieved at [#40](https://github.com/ProjectMapK/jackson-module-kogera/pull/40).
 - Support for less than `Kotlin 1.6.x`(including grid test building with `CI`)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.module.kotlin.deser.deserializers.KotlinDeserialize
 import com.fasterxml.jackson.module.kotlin.deser.deserializers.KotlinKeyDeserializers
 import com.fasterxml.jackson.module.kotlin.deser.singleton_support.KotlinBeanDeserializerModifier
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.KotlinInstantiators
+import com.fasterxml.jackson.module.kotlin.ser.serializers.KotlinKeySerializers
 import com.fasterxml.jackson.module.kotlin.ser.serializers.KotlinSerializers
 import java.util.*
 
@@ -79,6 +80,7 @@ public class KotlinModule private constructor(
         context.addDeserializers(KotlinDeserializers())
         context.addKeyDeserializers(KotlinKeyDeserializers)
         context.addSerializers(KotlinSerializers())
+        context.addKeySerializers(KotlinKeySerializers())
 
         // ranges
         context.setMixInAnnotations(ClosedRange::class.java, ClosedRangeMixin::class.java)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinKeySerializers.kt
@@ -1,0 +1,37 @@
+package com.fasterxml.jackson.module.kotlin.ser.serializers
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.BeanDescription
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializationConfig
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.module.kotlin.isUnboxableValueClass
+
+internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
+    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
+        val method = value::class.java.getMethod("unbox-impl")
+        val unboxed = method.invoke(value)
+
+        if (unboxed == null) {
+            val javaType = provider.typeFactory.constructType(method.genericReturnType)
+            provider.findNullKeySerializer(javaType, null).serialize(null, gen, provider)
+            return
+        }
+
+        provider.findKeySerializer(unboxed::class.java, null).serialize(unboxed, gen, provider)
+    }
+}
+
+internal class KotlinKeySerializers : Serializers.Base() {
+    override fun findSerializer(
+        config: SerializationConfig,
+        type: JavaType,
+        beanDesc: BeanDescription
+    ): JsonSerializer<*>? = when {
+        type.rawClass.isUnboxableValueClass() -> ValueClassUnboxKeySerializer
+        else -> null
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinSerializers.kt
@@ -46,10 +46,8 @@ internal object ULongSerializer : StdSerializer<ULong>(ULong::class.java) {
     }
 }
 
-// Class must be UnboxableValueClass.
-private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods
-    .find { method -> Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonValue } }
-
+// In accordance with kotlinx.serialization,
+// value classes are unboxed and serialized if they do not have a specified serializer.
 internal object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) {
     override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
         val unboxed = value::class.java.getMethod("unbox-impl").invoke(value)
@@ -62,6 +60,10 @@ internal object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) 
         provider.findValueSerializer(unboxed::class.java).serialize(unboxed, gen, provider)
     }
 }
+
+// Class must be UnboxableValueClass.
+private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods
+    .find { method -> Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonValue } }
 
 internal class ValueClassStaticJsonValueSerializer<T>(
     t: Class<T>,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/ValueClasses.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/ValueClasses.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer
 value class Primitive(val v: Int) {
     class Serializer : StdSerializer<Primitive>(Primitive::class.java) {
         override fun serialize(value: Primitive, gen: JsonGenerator, provider: SerializerProvider) {
-            gen.writeNumber(value.v)
+            gen.writeNumber(value.v + 100)
         }
     }
 }
@@ -17,7 +17,7 @@ value class Primitive(val v: Int) {
 value class NonNullObject(val v: String) {
     class Serializer : StdSerializer<NonNullObject>(NonNullObject::class.java) {
         override fun serialize(value: NonNullObject, gen: JsonGenerator, provider: SerializerProvider) {
-            gen.writeString(value.v)
+            gen.writeString("${value.v}-ser")
         }
     }
 }
@@ -26,7 +26,7 @@ value class NonNullObject(val v: String) {
 value class NullableObject(val v: String?) {
     class Serializer : StdSerializer<NullableObject>(NullableObject::class.java) {
         override fun serialize(value: NullableObject, gen: JsonGenerator, provider: SerializerProvider) {
-            value.v?.let { gen.writeString(it) } ?: gen.writeNull()
+            gen.writeString(value.v?.let { "$it-ser" } ?: "NULL")
         }
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/non_null_object/ByAnnotationTest.kt
@@ -26,8 +26,8 @@ class ByAnnotationTest {
         Assertions.assertEquals(
             """
                 {
-                  "getterAnn" : "foo",
-                  "fieldAnn" : "bar"
+                  "getterAnn" : "foo-ser",
+                  "fieldAnn" : "bar-ser"
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -48,8 +48,8 @@ class ByAnnotationTest {
         Assertions.assertEquals(
             """
                 {
-                  "getterAnn" : "foo",
-                  "fieldAnn" : "bar"
+                  "getterAnn" : "foo-ser",
+                  "fieldAnn" : "bar-ser"
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NonNullValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NonNullValueTest.kt
@@ -26,8 +26,8 @@ class NonNullValueTest {
         Assertions.assertEquals(
             """
                 {
-                  "getterAnn" : "foo",
-                  "fieldAnn" : "bar"
+                  "getterAnn" : "foo-ser",
+                  "fieldAnn" : "bar-ser"
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -48,8 +48,8 @@ class NonNullValueTest {
         Assertions.assertEquals(
             """
                 {
-                  "getterAnn" : "foo",
-                  "fieldAnn" : "bar"
+                  "getterAnn" : "foo-ser",
+                  "fieldAnn" : "bar-ser"
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NullValueTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/nullable_object/by_annotation/NullValueTest.kt
@@ -26,8 +26,8 @@ class NullValueTest {
         Assertions.assertNotEquals(
             """
                 {
-                  "getterAnn" : null,
-                  "fieldAnn" : null
+                  "getterAnn" : "NULL",
+                  "fieldAnn" : "NULL"
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -48,8 +48,8 @@ class NullValueTest {
         Assertions.assertEquals(
             """
                 {
-                  "getterAnn" : null,
-                  "fieldAnn" : null
+                  "getterAnn" : "NULL",
+                  "fieldAnn" : "NULL"
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/primitive/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/primitive/ByAnnotationTest.kt
@@ -27,8 +27,8 @@ class ByAnnotationTest {
         assertEquals(
             """
                 {
-                  "getterAnn" : 0,
-                  "fieldAnn" : 1
+                  "getterAnn" : 100,
+                  "fieldAnn" : 101
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -49,8 +49,8 @@ class ByAnnotationTest {
         assertEquals(
             """
                 {
-                  "getterAnn" : 0,
-                  "fieldAnn" : 1
+                  "getterAnn" : 100,
+                  "fieldAnn" : 101
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -87,8 +87,8 @@ class ByAnnotationTest {
         assertNotEquals(
             """
                 {
-                  "nonNull" : 0,
-                  "nullable" : 1
+                  "nonNull" : 100,
+                  "nullable" : 101
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/GitHub524.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/GitHub524.kt
@@ -31,7 +31,7 @@ class GitHub524 {
         val bar: HasSerializer = HasSerializer(1),
         val baz: HasSerializer = HasSerializer(null),
         val qux: HasSerializer? = null,
-        // If there is no serializer.
+        // If there is no serializer, it will be unboxed as the existing.
         val quux: NoSerializer = NoSerializer(2)
     )
 
@@ -49,9 +49,7 @@ class GitHub524 {
                   "bar" : "HasSerializer(value=1)",
                   "baz" : "HasSerializer(value=null)",
                   "qux" : null,
-                  "quux" : {
-                    "value" : 2
-                  }
+                  "quux" : 2
                 }
             """.trimIndent(),
             writer.writeValueAsString(Poko())

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/Github356.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/Github356.kt
@@ -20,7 +20,7 @@ class TestGithub356 {
     @Test
     fun serializeInlineClass() {
         assertEquals(
-            """{"inlineClassProperty":{"value":"bar"}}""",
+            """{"inlineClassProperty":"bar"}""",
             mapper.writeValueAsString(ClassWithInlineMember(InlineClass("bar")))
         )
     }
@@ -36,7 +36,7 @@ class TestGithub356 {
     @Test
     fun serializeValueClass() {
         assertEquals(
-            """{"valueClassProperty":{"value":"bar"}}""",
+            """{"valueClassProperty":"bar"}""",
             mapper.writeValueAsString(ClassWithValueMember(ValueClass("bar")))
         )
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/Github464.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/Github464.kt
@@ -51,7 +51,7 @@ class Github464 {
         val grault: Array<ValueClass?>,
         val garply: WrapperClass,
         val waldo: WrapperClass?,
-        val fred: Map<ValueClass?, ValueClass?>
+        val fred: Map<ValueClass, ValueClass?>
     ) : AbstractGetter<ValueClass>(), IGetter<ValueClass>
 
     object NullValueSerializer : StdSerializer<Any>(Any::class.java) {
@@ -77,7 +77,7 @@ class Github464 {
             grault = arrayOf(zeroValue, null),
             garply = WrapperClass(zeroValue),
             waldo = null,
-            fred = mapOf(zeroValue to zeroValue, oneValue to null, nullValue to nullValue, null to null)
+            fred = mapOf(zeroValue to zeroValue, oneValue to null, nullValue to nullValue)
         )
 
         @Test
@@ -90,47 +90,24 @@ class Github464 {
             assertEquals(
                 """
                     {
-                      "foo" : {
-                        "value" : 0
-                      },
+                      "foo" : 0,
                       "bar" : null,
-                      "baz" : {
-                        "value" : 0
-                      },
-                      "qux" : {
-                        "value" : 0
-                      },
-                      "quux" : {
-                        "value" : 0
-                      },
-                      "corge" : [ {
-                        "value" : 0
-                      }, null ],
-                      "grault" : [ {
-                        "value" : 0
-                      }, null ],
+                      "baz" : 0,
+                      "qux" : 0,
+                      "quux" : 0,
+                      "corge" : [ 0, null ],
+                      "grault" : [ 0, null ],
                       "garply" : {
-                        "inlineField" : {
-                          "value" : 0
-                        }
+                        "inlineField" : 0
                       },
                       "waldo" : null,
                       "fred" : {
-                        "ValueClass(value=0)" : {
-                          "value" : 0
-                        },
-                        "ValueClass(value=1)" : null,
-                        "ValueClass(value=null)" : {
-                          "value" : null
-                        },
+                        "0" : 0,
+                        "1" : null,
                         "null-key" : null
                       },
-                      "xyzzy" : {
-                        "value" : 0
-                      },
-                      "plugh" : {
-                        "value" : 0
-                      }
+                      "xyzzy" : 0,
+                      "plugh" : 0
                     }
                 """.trimIndent(),
                 writer.writeValueAsString(target)
@@ -149,47 +126,24 @@ class Github464 {
             assertEquals(
                 """
                     {
-                      "foo" : {
-                        "value" : 0
-                      },
+                      "foo" : 0,
                       "bar" : "null-value",
-                      "baz" : {
-                        "value" : 0
-                      },
-                      "qux" : {
-                        "value" : 0
-                      },
-                      "quux" : {
-                        "value" : 0
-                      },
-                      "corge" : [ {
-                        "value" : 0
-                      }, "null-value" ],
-                      "grault" : [ {
-                        "value" : 0
-                      }, "null-value" ],
+                      "baz" : 0,
+                      "qux" : 0,
+                      "quux" : 0,
+                      "corge" : [ 0, "null-value" ],
+                      "grault" : [ 0, "null-value" ],
                       "garply" : {
-                        "inlineField" : {
-                          "value" : 0
-                        }
+                        "inlineField" : 0
                       },
                       "waldo" : "null-value",
                       "fred" : {
-                        "ValueClass(value=0)" : {
-                          "value" : 0
-                        },
-                        "ValueClass(value=1)" : "null-value",
-                        "ValueClass(value=null)" : {
-                          "value" : "null-value"
-                        },
+                        "0" : 0,
+                        "1" : "null-value",
                         "null-key" : "null-value"
                       },
-                      "xyzzy" : {
-                        "value" : 0
-                      },
-                      "plugh" : {
-                        "value" : 0
-                      }
+                      "xyzzy" : 0,
+                      "plugh" : 0
                     }
                 """.trimIndent(),
                 writer.writeValueAsString(target)


### PR DESCRIPTION
In `kogera`, I changed to not `unbox` at serialization (#37), considering the case that multiple properties are included.
On the other hand, `kotlinx.serialization` basically unboxes `kotlinx.serialization`, so this change was reverted.
https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/value-classes.md

Fixed existing tests to match this change.