### PR TITLE
Partial fix for #46

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.module.kotlin
 
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.KmType
@@ -66,6 +67,9 @@ internal val defaultConstructorMarker: Class<*> by lazy {
 // Kotlin-specific types such as kotlin.String will result in an error,
 // but are ignored because they do not result in errors in internal use cases.
 internal fun String.reconstructClass(): Class<*> = Class.forName(this.replace(".", "$").replace("/", "."))
+
+internal fun KmType.reconstructClassOrNull(): Class<*>? = (classifier as? KmClassifier.Class)
+    ?.let { kotlin.runCatching { it.name.reconstructClass() }.getOrNull() }
 
 internal fun KmClass.findKmConstructor(constructor: Constructor<*>): KmConstructor? {
     val descHead = constructor.parameterTypes.toDescString()

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinClassIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinClassIntrospector.kt
@@ -1,0 +1,57 @@
+package com.fasterxml.jackson.module.kotlin
+
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.SerializationConfig
+import com.fasterxml.jackson.databind.introspect.AnnotatedConstructor
+import com.fasterxml.jackson.databind.introspect.BasicBeanDescription
+import com.fasterxml.jackson.databind.introspect.BasicClassIntrospector
+import com.fasterxml.jackson.databind.introspect.POJOPropertiesCollector
+
+// If the constructor has value class parameter,
+// annotations given to synthetic constructor parameter is injected into that constructor parameter.
+private fun AnnotatedConstructor.injectSyntheticAnnotations() {
+    val constructor = annotated
+
+    @Suppress("UNCHECKED_CAST")
+    val syntheticParams = constructor.parameterTypes.copyOf(constructor.parameterCount + 1)
+        .apply { this[constructor.parameterCount] = defaultConstructorMarker } as Array<Class<*>>
+    // Try to get syntheticConstructor, and if not, do nothing.
+    val syntheticConstructor = runCatching { declaringClass.getDeclaredConstructor(*syntheticParams) }
+        .getOrNull()
+        ?: return
+
+    (0 until constructor.parameterCount).forEach { i ->
+        val map = getParameterAnnotations(i)
+        syntheticConstructor.parameterAnnotations[i].forEach { map.add(it) }
+    }
+}
+
+internal class KotlinBeanDescription(coll: POJOPropertiesCollector) : BasicBeanDescription(coll) {
+    init {
+        this.constructors?.forEach { it.injectSyntheticAnnotations() }
+    }
+}
+
+// Almost all copies of super @2.14.1
+internal object KotlinClassIntrospector : BasicClassIntrospector() {
+    override fun forSerialization(
+        config: SerializationConfig,
+        type: JavaType,
+        r: MixInResolver
+    ): BasicBeanDescription {
+        // minor optimization: for some JDK types do minimal introspection
+        return _findStdTypeDesc(config, type)
+            // As per [databind#550], skip full introspection for some of standard
+            // structured types as well
+            ?: _findStdJdkCollectionDesc(config, type)
+            ?: run {
+                val coll = collectProperties(config, type, r, true)
+
+                if (type.rawClass.annotations.any { it is Metadata }) {
+                    KotlinBeanDescription(coll)
+                } else {
+                    BasicBeanDescription.forDeserialization(coll)
+                }
+            }
+    }
+}

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -77,6 +77,8 @@ public class KotlinModule private constructor(
         )
         context.appendAnnotationIntrospector(KotlinNamesAnnotationIntrospector(this, strictNullChecks, cache))
 
+        context.setClassIntrospector(KotlinClassIntrospector)
+
         context.addDeserializers(KotlinDeserializers())
         context.addKeyDeserializers(KotlinKeyDeserializers)
         context.addSerializers(KotlinSerializers())

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/primitive/ByAnnotationTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/serializer/by_annotation/primitive/ByAnnotationTest.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin._integration.ser.value_class.serializ
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.testPrettyWriter
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
 
 class ByAnnotationTest {
@@ -14,6 +13,8 @@ class ByAnnotationTest {
     }
 
     data class NonNullSrc(
+        @JsonSerialize(using = Primitive.Serializer::class)
+        val paramAnn: Primitive,
         @get:JsonSerialize(using = Primitive.Serializer::class)
         val getterAnn: Primitive,
         @field:JsonSerialize(using = Primitive.Serializer::class)
@@ -22,13 +23,14 @@ class ByAnnotationTest {
 
     @Test
     fun nonNull() {
-        val src = NonNullSrc(Primitive(0), Primitive(1))
+        val src = NonNullSrc(Primitive(0), Primitive(1), Primitive(2))
 
         assertEquals(
             """
                 {
-                  "getterAnn" : 100,
-                  "fieldAnn" : 101
+                  "paramAnn" : 100,
+                  "getterAnn" : 101,
+                  "fieldAnn" : 102
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -36,6 +38,8 @@ class ByAnnotationTest {
     }
 
     data class NullableSrc(
+        @JsonSerialize(using = Primitive.Serializer::class)
+        val paramAnn: Primitive?,
         @get:JsonSerialize(using = Primitive.Serializer::class)
         val getterAnn: Primitive?,
         @field:JsonSerialize(using = Primitive.Serializer::class)
@@ -44,13 +48,14 @@ class ByAnnotationTest {
 
     @Test
     fun nullableWithoutNull() {
-        val src = NullableSrc(Primitive(0), Primitive(1))
+        val src = NullableSrc(Primitive(0), Primitive(1), Primitive(2))
 
         assertEquals(
             """
                 {
-                  "getterAnn" : 100,
-                  "fieldAnn" : 101
+                  "paramAnn" : 100,
+                  "getterAnn" : 101,
+                  "fieldAnn" : 102
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)
@@ -59,36 +64,14 @@ class ByAnnotationTest {
 
     @Test
     fun nullableWithNull() {
-        val src = NullableSrc(null, null)
+        val src = NullableSrc(null, null, null)
 
         assertEquals(
             """
                 {
+                  "paramAnn" : null,
                   "getterAnn" : null,
                   "fieldAnn" : null
-                }
-            """.trimIndent(),
-            writer.writeValueAsString(src)
-        )
-    }
-
-    data class Failing(
-        @JsonSerialize(using = Primitive.Serializer::class)
-        val nonNull: Primitive,
-        @JsonSerialize(using = Primitive.Serializer::class)
-        val nullable: Primitive?
-    )
-
-    // #46
-    @Test
-    fun failing() {
-        val src = Failing(Primitive(0), Primitive(1))
-
-        assertNotEquals(
-            """
-                {
-                  "nonNull" : 100,
-                  "nullable" : 101
                 }
             """.trimIndent(),
             writer.writeValueAsString(src)


### PR DESCRIPTION
Fix #46 by changing the original annotation given to `Synthetic Constructor` parameters to inject them into the constructor parameters handled by `Jackson`.
However, more validation and modification was needed to apply this to deserialization, so it is not included in this PR.