### PR TITLE
Modified to use SpreadWrapper in constructor and method acquisition processing

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
@@ -1,4 +1,4 @@
-package com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator;
+package com.fasterxml.jackson.module.kotlin;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
@@ -15,7 +15,7 @@ class SpreadWrapper {
         return constructor.newInstance(initargs);
     }
 
-    public static Object invoke(
+    static Object invoke(
             @NotNull Method method,
             @Nullable Object instance,
             @NotNull Object[] args

--- a/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 abstract class SpreadWrapper {
     private SpreadWrapper() {}
 
+    @NotNull
     static <T> T newInstance(
             @NotNull Constructor<T> constructor,
             @NotNull Object[] initargs
@@ -17,6 +18,7 @@ abstract class SpreadWrapper {
         return constructor.newInstance(initargs);
     }
 
+    @Nullable
     static Object invoke(
             @NotNull Method method,
             @Nullable Object instance,

--- a/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
@@ -26,4 +26,21 @@ abstract class SpreadWrapper {
     ) throws InvocationTargetException, IllegalAccessException {
         return method.invoke(instance, args);
     }
+
+    @NotNull
+    static <T> Constructor<T> getDeclaredConstructor(
+            @NotNull Class<T> clazz,
+            @NotNull Class<?>[] parameterTypes
+    ) throws NoSuchMethodException {
+        return clazz.getDeclaredConstructor(parameterTypes);
+    }
+
+    @NotNull
+    static Method getDeclaredMethod(
+            @NotNull Class<?> clazz,
+            @NotNull String name,
+            @NotNull Class<?>[] parameterTypes
+    ) throws NoSuchMethodException {
+        return clazz.getDeclaredMethod(name, parameterTypes);
+    }
 }

--- a/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
+++ b/src/main/java/com/fasterxml/jackson/module/kotlin/SpreadWrapper.java
@@ -7,7 +7,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-class SpreadWrapper {
+abstract class SpreadWrapper {
+    private SpreadWrapper() {}
+
     static <T> T newInstance(
             @NotNull Constructor<T> constructor,
             @NotNull Object[] initargs

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinClassIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinClassIntrospector.kt
@@ -17,7 +17,7 @@ private fun AnnotatedConstructor.injectSyntheticAnnotations() {
     val syntheticParams = constructor.parameterTypes.copyOf(constructor.parameterCount + 1)
         .apply { this[constructor.parameterCount] = defaultConstructorMarker } as Array<Class<*>>
     // Try to get syntheticConstructor, and if not, do nothing.
-    val syntheticConstructor = runCatching { declaringClass.getDeclaredConstructor(*syntheticParams) }
+    val syntheticConstructor = runCatching { declaringClass.getDeclaredConstructorBy(syntheticParams) }
         .getOrNull()
         ?: return
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/SpreadWrapperDelegates.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/SpreadWrapperDelegates.kt
@@ -1,0 +1,7 @@
+package com.fasterxml.jackson.module.kotlin
+
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+
+internal fun <T> Constructor<T>.call(args: Array<*>): T = SpreadWrapper.newInstance(this, args)
+internal fun Method.call(instance: Any?, args: Array<*>): Any? = SpreadWrapper.invoke(this, instance, args)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/SpreadWrapperDelegates.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/SpreadWrapperDelegates.kt
@@ -5,3 +5,8 @@ import java.lang.reflect.Method
 
 internal fun <T> Constructor<T>.call(args: Array<*>): T = SpreadWrapper.newInstance(this, args)
 internal fun Method.call(instance: Any?, args: Array<*>): Any? = SpreadWrapper.invoke(this, instance, args)
+
+internal fun <T> Class<T>.getDeclaredConstructorBy(parameterTypes: Array<Class<*>>): Constructor<T> =
+    SpreadWrapper.getDeclaredConstructor(this, parameterTypes)
+internal fun Class<*>.getDeclaredMethodBy(name: String, parameterTypes: Array<Class<*>>): Method =
+    SpreadWrapper.getDeclaredMethod(this, name, parameterTypes)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ConstructorValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ConstructorValueCreator.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator
 
+import com.fasterxml.jackson.module.kotlin.call
 import com.fasterxml.jackson.module.kotlin.defaultConstructorMarker
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.argument_bucket.ArgumentBucket
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.argument_bucket.BucketGenerator
@@ -50,7 +51,7 @@ internal class ConstructorValueCreator<T : Any>(
     }
 
     override fun callBy(args: ArgumentBucket): T = if (args.isFullInitialized) {
-        SpreadWrapper.newInstance(constructor, args.arguments)
+        constructor.call(args.arguments)
     } else {
         val valueParameterSize = args.valueParameterSize
         val maskSize = args.masks.size
@@ -61,6 +62,6 @@ internal class ConstructorValueCreator<T : Any>(
             defaultArgs[i + valueParameterSize] = args.masks[i]
         }
 
-        SpreadWrapper.newInstance(defaultConstructor, defaultArgs)
+        defaultConstructor.call(defaultArgs)
     }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ConstructorValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/ConstructorValueCreator.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.argument_buc
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.argument_bucket.BucketGenerator
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.calcMaskSize
 import com.fasterxml.jackson.module.kotlin.findKmConstructor
+import com.fasterxml.jackson.module.kotlin.getDeclaredConstructorBy
 import com.fasterxml.jackson.module.kotlin.hasVarargParam
 import kotlinx.metadata.KmClass
 import java.lang.reflect.Constructor
@@ -34,6 +35,7 @@ internal class ConstructorValueCreator<T : Any>(
     private val defaultConstructor: Constructor<T> by lazy {
         val maskSize = calcMaskSize(constructor.parameters.size)
 
+        @Suppress("UNCHECKED_CAST")
         val defaultTypes = constructor.parameterTypes.let {
             val parameterSize = it.size
             val temp = it.copyOf(parameterSize + maskSize + 1)
@@ -43,9 +45,9 @@ internal class ConstructorValueCreator<T : Any>(
             temp[parameterSize + maskSize] = defaultConstructorMarker
 
             temp
-        }
+        } as Array<Class<*>>
 
-        declaringClass.getDeclaredConstructor(*defaultTypes).apply {
+        declaringClass.getDeclaredConstructorBy(defaultTypes).apply {
             if (!this.isAccessible) this.isAccessible = true
         }
     }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/MethodValueCreator.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/deser/value_instantiator/creator/MethodValueCreator.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator
 
+import com.fasterxml.jackson.module.kotlin.call
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.argument_bucket.ArgumentBucket
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.argument_bucket.BucketGenerator
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.calcMaskSize
@@ -73,14 +74,14 @@ internal class MethodValueCreator<T>(private val method: Method, declaringKmClas
                 defaultArgs[i + valueParameterSize + 1] = it.masks[i]
             }
 
-            SpreadWrapper.invoke(defaultMethod, null, defaultArgs)
+            defaultMethod.call(null, defaultArgs)
         }
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun callBy(args: ArgumentBucket): T = if (args.isFullInitialized) {
         // It calls static method for simplicity, and is a little slower in terms of speed.
-        SpreadWrapper.invoke(method, null, args.arguments)
+        method.call(null, args.arguments)
     } else {
         defaultCaller(args)
     } as T


### PR DESCRIPTION
This eliminates the use of the `spread operator` and improves initialization speed.