### PR TITLE
Optimize string operations and some refactors

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -38,10 +38,20 @@ private val primitiveClassToDesc by lazy {
     )
 }
 
+// -> this.name.replace(".", "/")
+private fun Class<*>.descName(): String {
+    val replaced = name.toCharArray().apply {
+        for (i in indices) {
+            if (this[i] == '.') this[i] = '/'
+        }
+    }
+    return String(replaced)
+}
+
 private fun StringBuilder.appendDescriptor(clazz: Class<*>): StringBuilder = when {
     clazz.isPrimitive -> append(primitiveClassToDesc.getValue(clazz))
     clazz.isArray -> append('[').appendDescriptor(clazz.componentType)
-    else -> append("L${clazz.name.replace('.', '/')};")
+    else -> append("L${clazz.descName()};")
 }
 
 internal fun Array<Class<*>>.toDescBuilder(): StringBuilder = this
@@ -58,7 +68,7 @@ private val Class<*>.descriptor: String
     get() = when {
         isPrimitive -> primitiveClassToDesc.getValue(this).toString()
         isArray -> "[${componentType.descriptor}"
-        else -> "L${name.replace('.', '/')};"
+        else -> "L${this.descName()};"
     }
 
 internal fun Field.toSignature(): JvmFieldSignature =

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -73,7 +73,22 @@ internal val defaultConstructorMarker: Class<*> by lazy {
 
 // Kotlin-specific types such as kotlin.String will result in an error,
 // but are ignored because they do not result in errors in internal use cases.
-internal fun String.reconstructClass(): Class<*> = Class.forName(this.replace(".", "$").replace("/", "."))
+internal fun String.reconstructClass(): Class<*> {
+    // -> this.replace(".", "$").replace("/", ".")
+    val replaced = this.toCharArray().apply {
+        for (i in indices) {
+            val c = this[i]
+
+            if (c == '.') {
+                this[i] = '$'
+            } else if (c == '/') {
+                this[i] = '.'
+            }
+        }
+    }
+
+    return Class.forName(String(replaced))
+}
 
 internal fun KmType.reconstructClassOrNull(): Class<*>? = (classifier as? KmClassifier.Class)
     ?.let { kotlin.runCatching { it.name.reconstructClass() }.getOrNull() }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -45,8 +45,16 @@ private val Class<*>.descriptor: String
         else -> "L${name.replace('.', '/')};"
     }
 
-internal fun Array<Class<*>>.toDescString(): String =
-    joinToString(separator = "", prefix = "(", postfix = ")") { it.descriptor }
+private fun StringBuilder.appendDescriptor(clazz: Class<*>): StringBuilder = when {
+    clazz.isPrimitive -> append(primitiveClassToDesc.getValue(clazz))
+    clazz.isArray -> append('[').appendDescriptor(clazz.componentType)
+    else -> append("L${clazz.name.replace('.', '/')};")
+}
+
+internal fun Array<Class<*>>.toDescString(): String = this
+    .fold(StringBuilder("(")) { acc, cur -> acc.appendDescriptor(cur) }
+    .append(')')
+    .toString()
 
 internal fun Constructor<*>.toSignature(): JvmMethodSignature =
     JvmMethodSignature("<init>", parameterTypes.toDescString() + "V")

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/InternalCommons.kt
@@ -54,6 +54,7 @@ private fun StringBuilder.appendDescriptor(clazz: Class<*>): StringBuilder = whe
     else -> append("L${clazz.descName()};")
 }
 
+// -> this.joinToString(separator = "", prefix = "(", postfix = ")") { it.descriptor }
 internal fun Array<Class<*>>.toDescBuilder(): StringBuilder = this
     .fold(StringBuilder("(")) { acc, cur -> acc.appendDescriptor(cur) }
     .append(')')

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -3,7 +3,6 @@ package com.fasterxml.jackson.module.kotlin.annotation_introspector
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.introspect.Annotated
-import com.fasterxml.jackson.databind.introspect.AnnotatedField
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
@@ -47,10 +46,6 @@ internal class KotlinFallbackAnnotationIntrospector(
     ): String? = cache.getKmClass(member.declaringClass)?.let { kmClass ->
         when (member) {
             is AnnotatedMethod -> kmClass.findPropertyByGetter(member.annotated)?.name
-            is AnnotatedField -> {
-                val fieldSignature = member.annotated.toSignature()
-                kmClass.properties.find { it.fieldSignature == fieldSignature }?.name
-            }
             is AnnotatedParameter -> findKotlinParameterName(member, kmClass)
             else -> null
         }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/JvmFieldTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/JvmFieldTest.kt
@@ -1,0 +1,22 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JvmFieldTest {
+    data class Src(
+        @JvmField
+        val `foo-foo`: String,
+        @JvmField
+        val `-bar`: String
+    )
+
+    @Test
+    fun test() {
+        val mapper = jacksonObjectMapper()
+        val r = mapper.writeValueAsString(Src("foo", "bar"))
+
+        assertEquals("{\"foo-foo\":\"foo\",\"-bar\":\"bar\"}", r)
+    }
+}


### PR DESCRIPTION
Optimized `Metadata` related string operations.

In addition, the following optimizations were made

- Removed branch on `field` in `findImplicitPropertyName`
  - Because it was not processed in `kotlin-module` and no content was found to be affected by this branch
- Fixed `requireRebox` function to use cache in `KmClass` acquisition process