### PR TITLE
Optimize KotlinFallbackAnnotationIntrospector

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -51,7 +51,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
     /**
      * return null if declaringClass is not kotlin class
      */
-    fun valueCreatorFromJava(_creator: Executable): ValueCreator<*>? = when (val creator = _creator) {
+    fun valueCreatorFromJava(creator: Executable): ValueCreator<*>? = when (creator) {
         is Constructor<*> -> {
             creatorCache.get(creator)
                 ?: run {

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ReflectionCache.kt
@@ -1,9 +1,11 @@
 package com.fasterxml.jackson.module.kotlin
 
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.util.LRUMap
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator.ConstructorValueCreator
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator.MethodValueCreator
 import com.fasterxml.jackson.module.kotlin.deser.value_instantiator.creator.ValueCreator
+import com.fasterxml.jackson.module.kotlin.ser.ValueClassBoxConverter
 import kotlinx.metadata.KmClass
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
@@ -14,6 +16,10 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
     // This cache is used for both serialization and deserialization, so reserve a larger size from the start.
     private val classCache = LRUMap<Class<*>, Optional<KmClass>>(reflectionCacheSize, reflectionCacheSize)
     private val creatorCache: LRUMap<Executable, ValueCreator<*>>
+
+    // TODO: Consider whether the cache size should be reduced more,
+    //       since the cache is used only twice locally at initialization per property.
+    private val valueClassBoxConverterCache: LRUMap<AnnotatedMethod, Optional<ValueClassBoxConverter<*, *>>>
 
     init {
         // The current default value of reflectionCacheSize is 512.
@@ -28,6 +34,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
             reflectionCacheSize
         }
         creatorCache = LRUMap(initialEntries, reflectionCacheSize)
+        valueClassBoxConverterCache = LRUMap(initialEntries, reflectionCacheSize)
     }
 
     fun getKmClass(clazz: Class<*>): KmClass? {
@@ -69,4 +76,32 @@ internal class ReflectionCache(reflectionCacheSize: Int) {
             "Expected a constructor or method to create a Kotlin object, instead found ${creator.javaClass.name}"
         )
     } // we cannot reflect this method so do the default Java-ish behavior
+
+    private fun AnnotatedMethod.findValueClassBoxConverter(): ValueClassBoxConverter<*, *>? {
+        val getter = this.member.apply {
+            // If the return value of the getter is a value class,
+            // it will be serialized properly without doing anything.
+            // TODO: Verify the case where a value class encompasses another value class.
+            if (this.returnType.isUnboxableValueClass()) return null
+        }
+        val kotlinProperty = getKmClass(getter.declaringClass)?.findPropertyByGetter(getter)
+
+        // Since there was no way to directly determine whether returnType is a value class or not,
+        // Class is restored and processed.
+        return kotlinProperty?.returnType?.reconstructClassOrNull()?.let { clazz ->
+            clazz.takeIf { it.isUnboxableValueClass() }
+                ?.let { ValueClassBoxConverter(getter.returnType, it) }
+        }
+    }
+
+    fun findValueClassBoxConverterFrom(a: AnnotatedMethod): ValueClassBoxConverter<*, *>? {
+        val optional = valueClassBoxConverterCache.get(a)
+
+        return if (optional != null) {
+            optional
+        } else {
+            val value = Optional.ofNullable(a.findValueClassBoxConverter())
+            (valueClassBoxConverterCache.putIfAbsent(a, value) ?: value)
+        }.orElse(null)
+    }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
@@ -3,10 +3,10 @@ package com.fasterxml.jackson.module.kotlin.ser
 import com.fasterxml.jackson.databind.util.StdConverter
 
 // S is nullable because value corresponds to a nullable value class
-// @see KotlinNamesAnnotationIntrospector.findNullSerializer
+// @see KotlinFallbackAnnotationIntrospector.findNullSerializer
 internal class ValueClassBoxConverter<S : Any?, D : Any>(
     unboxedClass: Class<S>,
-    valueClass: Class<D>
+    val valueClass: Class<D>
 ) : StdConverter<S, D>() {
     private val boxMethod = valueClass.getDeclaredMethod("box-impl", unboxedClass).apply {
         if (!this.isAccessible) this.isAccessible = true


### PR DESCRIPTION
Optimization of `KotlineFallbackAnnotationIntrospector` to improve the problem of slow first-time processing of serialization.
The contents of the optimization are as follows.

- Reduce the number of reflection processes by integrating `hasIgnoreMarker` into `findPropertyAccess`.
- Changed the `ValueClassBoxConverter` acquisition process so that it is cached and used around.

## Benchmark results
### original
```
Benchmark                                     Mode  Cnt   Score   Error  Units
o.w.deser.A_1Props_Constructor.call             ss    5  20.021 ± 1.290  ms/op
o.w.deser.A_1Props_Constructor.call_default     ss    5  21.482 ± 1.143  ms/op
o.w.deser.A_1Props_Function.call                ss    5  21.852 ± 2.234  ms/op
o.w.deser.A_1Props_Function.call_default        ss    5  22.854 ± 1.051  ms/op
o.w.deser.E_5Props_Constructor.call             ss    5  20.855 ± 1.978  ms/op
o.w.deser.E_5Props_Constructor.call_default     ss    5  22.347 ± 1.030  ms/op
o.w.deser.E_5Props_Function.call                ss    5  23.280 ± 0.715  ms/op
o.w.deser.E_5Props_Function.call_default        ss    5  24.636 ± 1.458  ms/op
o.w.deser.T_20Props_Constructor.call            ss    5  23.945 ± 1.502  ms/op
o.w.deser.T_20Props_Constructor.call_default    ss    5  25.913 ± 1.791  ms/op
o.w.deser.T_20Props_Function.call               ss    5  28.484 ± 2.875  ms/op
o.w.deser.T_20Props_Function.call_default       ss    5  29.572 ± 1.218  ms/op
o.w.ser.A_1Props.call                           ss    5  55.035 ± 3.071  ms/op
o.w.ser.E_5Props.call                           ss    5  59.042 ± 3.804  ms/op
o.w.ser.T_20Props.call                          ss    5  67.898 ± 2.479  ms/op
```

### kogera(2.14.2)
```
Benchmark                                       Mode  Cnt   Score   Error  Units
o.w.m.deser.A_1Props_Constructor.call             ss    5  21.010 ± 1.361  ms/op
o.w.m.deser.A_1Props_Constructor.call_default     ss    5  22.444 ± 0.722  ms/op
o.w.m.deser.A_1Props_Function.call                ss    5  21.739 ± 1.460  ms/op
o.w.m.deser.A_1Props_Function.call_default        ss    5  23.136 ± 2.382  ms/op
o.w.m.deser.E_5Props_Constructor.call             ss    5  23.523 ± 0.472  ms/op
o.w.m.deser.E_5Props_Constructor.call_default     ss    5  24.957 ± 1.894  ms/op
o.w.m.deser.E_5Props_Function.call                ss    5  24.426 ± 1.615  ms/op
o.w.m.deser.E_5Props_Function.call_default        ss    5  25.944 ± 2.602  ms/op
o.w.m.deser.T_20Props_Constructor.call            ss    5  27.611 ± 2.137  ms/op
o.w.m.deser.T_20Props_Constructor.call_default    ss    5  29.228 ± 1.855  ms/op
o.w.m.deser.T_20Props_Function.call               ss    5  29.693 ± 0.855  ms/op
o.w.m.deser.T_20Props_Function.call_default       ss    5  31.801 ± 2.640  ms/op
o.w.m.ser.A_1Props.call                           ss    5  72.660 ± 3.609  ms/op
o.w.m.ser.E_5Props.call                           ss    5  74.568 ± 8.153  ms/op
o.w.m.ser.T_20Props.call                          ss    5  83.585 ± 3.255  ms/op
```

### kogera(188f22aca769c84ed29739a1bb8bbab9263054dd)
```
Benchmark                                       Mode  Cnt   Score   Error  Units
o.w.m.deser.A_1Props_Constructor.call             ss    5  21.669 ± 5.868  ms/op
o.w.m.deser.A_1Props_Constructor.call_default     ss    5  22.810 ± 2.289  ms/op
o.w.m.deser.A_1Props_Function.call                ss    5  21.522 ± 1.448  ms/op
o.w.m.deser.A_1Props_Function.call_default        ss    5  23.436 ± 2.674  ms/op
o.w.m.deser.E_5Props_Constructor.call             ss    5  23.345 ± 1.640  ms/op
o.w.m.deser.E_5Props_Constructor.call_default     ss    5  24.627 ± 2.441  ms/op
o.w.m.deser.E_5Props_Function.call                ss    5  24.568 ± 2.223  ms/op
o.w.m.deser.E_5Props_Function.call_default        ss    5  26.149 ± 2.384  ms/op
o.w.m.deser.T_20Props_Constructor.call            ss    5  27.058 ± 1.156  ms/op
o.w.m.deser.T_20Props_Constructor.call_default    ss    5  28.689 ± 2.530  ms/op
o.w.m.deser.T_20Props_Function.call               ss    5  29.611 ± 8.220  ms/op
o.w.m.deser.T_20Props_Function.call_default       ss    5  30.671 ± 2.473  ms/op
o.w.m.ser.A_1Props.call                           ss    5  70.982 ± 1.751  ms/op
o.w.m.ser.E_5Props.call                           ss    5  72.754 ± 4.667  ms/op
o.w.m.ser.T_20Props.call                          ss    5  81.931 ± 5.392  ms/op
```