### PR TITLE
Fixed problem with deserialization failing for correct collections when StrictNullCkecks is enabled.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.module.kotlin.annotation_introspector
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.introspect.Annotated
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember
@@ -101,7 +102,7 @@ internal class KotlinFallbackAnnotationIntrospector(
 
             valueParameter.createValueClassUnboxConverterOrNull(rawType) ?: run {
                 if (strictNullChecks) {
-                    valueParameter.createStrictNullChecksConverterOrNull(rawType)
+                    valueParameter.createStrictNullChecksConverterOrNull(a.type, rawType)
                 } else {
                     null
                 }
@@ -137,15 +138,15 @@ private fun ValueParameter.createValueClassUnboxConverterOrNull(rawType: Class<*
 // @see com.fasterxml.jackson.module.kotlin._ported.test.StrictNullChecksTest#testListOfGenericWithNullValue
 private fun ValueParameter.isNullishTypeAt(index: Int) = arguments.getOrNull(index)?.isNullable ?: true
 
-private fun ValueParameter.createStrictNullChecksConverterOrNull(rawType: Class<*>): Converter<*, *>? {
+private fun ValueParameter.createStrictNullChecksConverterOrNull(type: JavaType, rawType: Class<*>): Converter<*, *>? {
     @Suppress("UNCHECKED_CAST")
     return when {
         Array::class.java.isAssignableFrom(rawType) && !this.isNullishTypeAt(0) ->
-            CollectionValueStrictNullChecksConverter.ForArray(this)
+            CollectionValueStrictNullChecksConverter.ForArray(type, this)
         Iterable::class.java.isAssignableFrom(rawType) && !this.isNullishTypeAt(0) ->
-            CollectionValueStrictNullChecksConverter.ForIterable(this)
+            CollectionValueStrictNullChecksConverter.ForIterable(type, this)
         Map::class.java.isAssignableFrom(rawType) && !this.isNullishTypeAt(1) ->
-            MapValueStrictNullChecksConverter(this)
+            MapValueStrictNullChecksConverter(type, this)
         else -> null
     }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/StrictNullChecksTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/StrictNullChecksTest.kt
@@ -1,0 +1,78 @@
+package com.fasterxml.jackson.module.kotlin._integration.deser
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StrictNullChecksTest {
+    val mapper: ObjectMapper = ObjectMapper()
+        .registerModule(
+            KotlinModule.Builder()
+                .enable(KotlinFeature.StrictNullChecks)
+                .build()
+        )
+
+    class ArrayWrapper(val value: Array<Int>)
+    data class ListWrapper(val value: List<Int>)
+    data class MapWrapper(val value: Map<String, Int>)
+
+    @Nested
+    inner class NonNullInput {
+        @Test
+        fun array() {
+            val expected = ArrayWrapper(arrayOf(1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<ArrayWrapper>(src)
+
+            assertArrayEquals(expected.value, result.value)
+        }
+
+        @Test
+        fun list() {
+            val expected = ListWrapper(listOf(1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<ListWrapper>(src)
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun map() {
+            val expected = MapWrapper(mapOf("foo" to 1))
+            val src = mapper.writeValueAsString(expected)
+            val result = mapper.readValue<MapWrapper>(src)
+
+            assertEquals(expected, result)
+        }
+    }
+
+    data class AnyWrapper(val value: Any)
+
+    @Nested
+    inner class NullInput {
+        @Test
+        fun array() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<MissingKotlinParameterException> { mapper.readValue<ArrayWrapper>(src) }
+        }
+
+        @Test
+        fun list() {
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            assertThrows<MissingKotlinParameterException> { mapper.readValue<ListWrapper>(src) }
+        }
+
+        @Test
+        fun map() {
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            assertThrows<MissingKotlinParameterException> { mapper.readValue<MapWrapper>(src) }
+        }
+    }
+}


### PR DESCRIPTION
Probably due to a `Jackson` problem that caused `Array<T>` to be deserialized to `Array<Array<T>>`.