### PR TITLE
Modified to cache `ValueClassBoxConverter` and related instances.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMember
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.introspect.AnnotatedParameter
 import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
-import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
 import com.fasterxml.jackson.databind.util.Converter
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.ReflectionCache
@@ -125,7 +124,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     override fun findNullSerializer(am: Annotated): JsonSerializer<*>? = (am as? AnnotatedMethod)?.let { _ ->
         cache.findValueClassReturnType(am)
             ?.takeIf { it.requireRebox() }
-            ?.let { StdDelegatingSerializer(cache.getValueClassBoxConverter(am.rawReturnType, it)) }
+            ?.let { cache.getValueClassBoxConverter(am.rawReturnType, it).delegatingSerializer }
     }
 }
 

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.ser
 
+import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
 import com.fasterxml.jackson.databind.util.StdConverter
 
 // S is nullable because value corresponds to a nullable value class
@@ -14,4 +15,6 @@ internal class ValueClassBoxConverter<S : Any?, D : Any>(
 
     @Suppress("UNCHECKED_CAST")
     override fun convert(value: S): D = boxMethod.invoke(null, value) as D
+
+    val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/ValueClassBoxConverter.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.util.StdConverter
 // @see KotlinFallbackAnnotationIntrospector.findNullSerializer
 internal class ValueClassBoxConverter<S : Any?, D : Any>(
     unboxedClass: Class<S>,
-    val valueClass: Class<D>
+    valueClass: Class<D>
 ) : StdConverter<S, D>() {
     private val boxMethod = valueClass.getDeclaredMethod("box-impl", unboxedClass).apply {
         if (!this.isAccessible) this.isAccessible = true


### PR DESCRIPTION
- Do not create `ValueClassBoxConverter` for the same class more than once
- Do not create `StdDelegatingSerializer` for the same `ValueClassBoxConverter` more than once