### PR TITLE
Added an argumentless constructor to KotlinModule

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/KotlinModule.kt
@@ -51,6 +51,12 @@ public class KotlinModule private constructor(
         builder.isEnabled(StrictNullChecks)
     )
 
+    @Deprecated(
+        message = "This is an API for compatibility; use Builder.",
+        level = DeprecationLevel.ERROR
+    )
+    public constructor() : this(Builder())
+
     public companion object {
         private const val serialVersionUID = 1L
     }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/InitModuleTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/InitModuleTest.kt
@@ -1,0 +1,12 @@
+package com.fasterxml.jackson.module.kotlin._integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class InitModuleTest {
+    @Test
+    fun findAndRegisterModulesTest() {
+        assertDoesNotThrow { ObjectMapper().findAndRegisterModules() }
+    }
+}


### PR DESCRIPTION
Errors related to `ObjectMapper::findAndRegisterModules` have been fixed.