### PR TITLE
Minor optimizations

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -65,11 +65,9 @@ internal class KotlinFallbackAnnotationIntrospector(
     }
 
     private fun findKotlinParameterName(param: AnnotatedParameter, kmClass: KmClass): String? {
-        val declaringClass = param.declaringClass
-
         return when (val member = param.owner.member) {
             is Constructor<*> -> kmClass.findKmConstructor(member)?.let { it.valueParameters[param.index].name }
-            is Method -> findKotlinFactoryParameterName(declaringClass, kmClass, member, param.index)
+            is Method -> findKotlinFactoryParameterName(param.declaringClass, kmClass, member, param.index)
             else -> null
         }
     }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -41,12 +41,10 @@ internal class KotlinFallbackAnnotationIntrospector(
     // since 2.4
     override fun findImplicitPropertyName(
         member: AnnotatedMember
-    ): String? = cache.getKmClass(member.declaringClass)?.let { kmClass ->
-        when (member) {
-            is AnnotatedMethod -> kmClass.findPropertyByGetter(member.annotated)?.name
-            is AnnotatedParameter -> findKotlinParameterName(member, kmClass)
-            else -> null
-        }
+    ): String? = when (member) {
+        is AnnotatedMethod -> cache.getKmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
+        is AnnotatedParameter -> cache.getKmClass(member.declaringClass)?.let { findKotlinParameterName(member, it) }
+        else -> null
     }
 
     private fun findKotlinFactoryParameterName(

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -42,7 +42,11 @@ internal class KotlinFallbackAnnotationIntrospector(
     override fun findImplicitPropertyName(
         member: AnnotatedMember
     ): String? = when (member) {
-        is AnnotatedMethod -> cache.getKmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
+        is AnnotatedMethod -> if (member.parameterCount == 0) {
+            cache.getKmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
+        } else {
+            null
+        }
         is AnnotatedParameter -> cache.getKmClass(member.declaringClass)?.let { findKotlinParameterName(member, it) }
         else -> null
     }


### PR DESCRIPTION
Detailed optimization was performed to reduce the number of theoretical calculations.
However, the impact was smaller than the initialization of `KmClass` and did not improve the benchmark score.