### PR TITLE
Minor optimizations

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.module.kotlin.isNullable
 import com.fasterxml.jackson.module.kotlin.isUnboxableValueClass
 import com.fasterxml.jackson.module.kotlin.reconstructClassOrNull
 import com.fasterxml.jackson.module.kotlin.toSignature
-import kotlinx.metadata.KmClass
 import kotlinx.metadata.jvm.fieldSignature
 import kotlinx.metadata.jvm.setterSignature
 import kotlinx.metadata.jvm.signature
@@ -39,39 +38,32 @@ internal class KotlinFallbackAnnotationIntrospector(
     private val cache: ReflectionCache
 ) : NopAnnotationIntrospector() {
     // since 2.4
-    override fun findImplicitPropertyName(
-        member: AnnotatedMember
-    ): String? = when (member) {
+    override fun findImplicitPropertyName(member: AnnotatedMember): String? = when (member) {
         is AnnotatedMethod -> if (member.parameterCount == 0) {
             cache.getKmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
         } else {
             null
         }
-        is AnnotatedParameter -> cache.getKmClass(member.declaringClass)?.let { findKotlinParameterName(member, it) }
+        is AnnotatedParameter -> findKotlinParameterName(member)
         else -> null
     }
 
-    private fun findKotlinFactoryParameterName(
-        declaringClass: Class<*>,
-        kmClass: KmClass,
-        member: Method,
-        index: Int
-    ) = kmClass.companionObject?.takeIf { _ -> Modifier.isStatic(member.modifiers) }?.let { companion ->
-        val companionKmClass = declaringClass.getDeclaredField(companion)
-            .type
-            .let { cache.getKmClass(it) }!!
-        val signature = member.toSignature()
+    private fun findKotlinParameterName(param: AnnotatedParameter): String? = when (val owner = param.owner.member) {
+        is Constructor<*> -> cache.getKmClass(param.declaringClass)
+            ?.findKmConstructor(owner)?.let { it.valueParameters[param.index].name }
+        is Method ->
+            owner.takeIf { _ -> Modifier.isStatic(owner.modifiers) }
+                ?.let { _ ->
+                    val companion = cache.getKmClass(param.declaringClass)?.companionObject ?: return@let null
+                    val companionKmClass = owner.declaringClass.getDeclaredField(companion)
+                        .type
+                        .let { cache.getKmClass(it) }!!
+                    val signature = owner.toSignature()
 
-        companionKmClass.functions.find { it.signature == signature }
-            ?.let { it.valueParameters[index].name }
-    }
-
-    private fun findKotlinParameterName(param: AnnotatedParameter, kmClass: KmClass): String? {
-        return when (val member = param.owner.member) {
-            is Constructor<*> -> kmClass.findKmConstructor(member)?.let { it.valueParameters[param.index].name }
-            is Method -> findKotlinFactoryParameterName(param.declaringClass, kmClass, member, param.index)
-            else -> null
-        }
+                    companionKmClass.functions.find { it.signature == signature }
+                        ?.let { it.valueParameters[param.index].name }
+                }
+        else -> null
     }
 
     // If it is not a property on Kotlin, it is not used to ser/deserialization

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -49,8 +49,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     }
 
     private fun findKotlinParameterName(param: AnnotatedParameter): String? = when (val owner = param.owner.member) {
-        is Constructor<*> -> cache.getKmClass(param.declaringClass)
-            ?.findKmConstructor(owner)?.let { it.valueParameters[param.index].name }
+        is Constructor<*> -> cache.getKmClass(param.declaringClass)?.findKmConstructor(owner)?.valueParameters
         is Method ->
             owner.takeIf { _ -> Modifier.isStatic(owner.modifiers) }
                 ?.let { _ ->
@@ -60,11 +59,10 @@ internal class KotlinFallbackAnnotationIntrospector(
                         .let { cache.getKmClass(it) }!!
                     val signature = owner.toSignature()
 
-                    companionKmClass.functions.find { it.signature == signature }
-                        ?.let { it.valueParameters[param.index].name }
+                    companionKmClass.functions.find { it.signature == signature }?.valueParameters
                 }
         else -> null
-    }
+    }?.let { it[param.index].name }
 
     // If it is not a property on Kotlin, it is not used to ser/deserialization
     override fun findPropertyAccess(ann: Annotated): JsonProperty.Access? = (ann as? AnnotatedMethod)?.let { _ ->

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -30,6 +30,7 @@ import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 
 // AnnotationIntrospector that overrides the behavior of the default AnnotationIntrospector
 // (in most cases, JacksonAnnotationIntrospector).
@@ -170,12 +171,10 @@ private fun hasCreatorConstructor(clazz: Class<*>, kmClass: KmClass, propertyNam
 
 // In the original, `isPossibleSingleString` comparison was disabled,
 // and if enabled, the behavior would have changed, so the comparison is skipped.
-private fun hasCreatorFunction(clazz: Class<*>, kmClass: KmClass): Boolean = kmClass.companionObject
-    ?.let { companion ->
-        clazz.getDeclaredField(companion).type.declaredMethods.any { it.hasCreatorAnnotation() }
-    } ?: false
+private fun hasCreatorFunction(clazz: Class<*>): Boolean = clazz.declaredMethods
+    .any { Modifier.isStatic(it.modifiers) && it.hasCreatorAnnotation() }
 
 private fun hasCreator(clazz: Class<*>, kmClass: KmClass): Boolean {
     val propertyNames = kmClass.properties.map { it.name }.toSet()
-    return hasCreatorConstructor(clazz, kmClass, propertyNames) || hasCreatorFunction(clazz, kmClass)
+    return hasCreatorConstructor(clazz, kmClass, propertyNames) || hasCreatorFunction(clazz)
 }


### PR DESCRIPTION
The main reductions were in the amount of reflection and the number of conversions to `KmClass`.
However, there was not much impact on the benchmark scores.