### PR TITLE
Modified to not load the entire Sequence into memory during serialization.

### DIFF
--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinSerializers.kt
@@ -16,8 +16,7 @@ import java.math.BigInteger
 
 internal object SequenceSerializer : StdSerializer<Sequence<*>>(Sequence::class.java) {
     override fun serialize(value: Sequence<*>, gen: JsonGenerator, provider: SerializerProvider) {
-        val materializedList = value.toList()
-        provider.defaultSerializeValue(materializedList, gen)
+        provider.defaultSerializeValue(value.iterator(), gen)
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/FasterXML/jackson-module-kotlin/issues/368