### PR TITLE
Support JsonKey in value class

### DIFF
--- a/docs/FixedIssues.md
+++ b/docs/FixedIssues.md
@@ -6,6 +6,7 @@ A list of issues that have not been resolved in `jackson-module-kotlin`, but hav
 - [Private getter with different return type hides property · Issue \#341](https://github.com/FasterXML/jackson-module-kotlin/issues/341)
 - [Remove \`kotlin\-reflect\` and replace it with \`kotlinx\-metadata\-jvm\` · Issue \#450](https://github.com/FasterXML/jackson-module-kotlin/issues/450)
 - [Remove deprecated method in KNAI · Issue \#508](https://github.com/FasterXML/jackson-module-kotlin/issues/508)
+- [Support JsonKey in value class · Issue \#536](https://github.com/FasterXML/jackson-module-kotlin/issues/536)
 - [Type Introspection: non\-nullable field with default is reported as required · Issue \#609](https://github.com/FasterXML/jackson-module-kotlin/issues/609)
 - [`JsonSerializer` is enabled when the value is an Object type with non\-null value and the property definition is nullable. · Issue \#618](https://github.com/FasterXML/jackson-module-kotlin/issues/618)
 - [About the problem that property names in \`Jackson\` and definitions in \`Kotlin\` are sometimes different\. · Issue \#630](https://github.com/FasterXML/jackson-module-kotlin/issues/630)

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinKeySerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinKeySerializers.kt
@@ -1,5 +1,6 @@
 package com.fasterxml.jackson.module.kotlin.ser.serializers
 
+import com.fasterxml.jackson.annotation.JsonKey
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.BeanDescription
 import com.fasterxml.jackson.databind.JavaType
@@ -9,6 +10,8 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import com.fasterxml.jackson.module.kotlin.isUnboxableValueClass
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 
 internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
     override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
@@ -25,13 +28,48 @@ internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.jav
     }
 }
 
+// Class must be UnboxableValueClass.
+private fun Class<*>.getStaticJsonKeyGetter(): Method? = this.declaredMethods.find { method ->
+    Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonKey && it.value }
+}
+
+internal class ValueClassStaticJsonKeySerializer<T>(
+    t: Class<T>,
+    private val staticJsonKeyGetter: Method
+) : StdSerializer<T>(t) {
+    private val keyType: Class<*> = staticJsonKeyGetter.returnType
+    private val unboxMethod: Method = t.getMethod("unbox-impl")
+
+    override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
+        val unboxed = unboxMethod.invoke(value)
+        // As shown in the processing of the factory function, jsonValueGetter is always a static method.
+        val jsonKey: Any? = staticJsonKeyGetter.invoke(null, unboxed)
+
+        val serializer = jsonKey
+            ?.let { provider.findKeySerializer(keyType, null) }
+            ?: provider.findNullKeySerializer(provider.constructType(keyType), null)
+
+        serializer.serialize(jsonKey, gen, provider)
+    }
+
+    companion object {
+        // `t` must be UnboxableValueClass.
+        // If create a function with a JsonValue in the value class,
+        // it will be compiled as a static method (= cannot be processed properly by Jackson),
+        // so use a ValueClassSerializer.StaticJsonValue to handle this.
+        fun createOrNull(t: Class<*>): StdSerializer<*>? =
+            t.getStaticJsonKeyGetter()?.let { ValueClassStaticJsonKeySerializer(t, it) }
+    }
+}
+
 internal class KotlinKeySerializers : Serializers.Base() {
     override fun findSerializer(
         config: SerializationConfig,
         type: JavaType,
         beanDesc: BeanDescription
     ): JsonSerializer<*>? = when {
-        type.rawClass.isUnboxableValueClass() -> ValueClassUnboxKeySerializer
+        type.rawClass.isUnboxableValueClass() -> ValueClassStaticJsonKeySerializer.createOrNull(type.rawClass)
+            ?: ValueClassUnboxKeySerializer
         else -> null
     }
 }

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinSerializers.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/ser/serializers/KotlinSerializers.kt
@@ -55,8 +55,9 @@ internal object ValueClassUnboxSerializer : StdSerializer<Any>(Any::class.java) 
 }
 
 // Class must be UnboxableValueClass.
-private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods
-    .find { method -> Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonValue } }
+private fun Class<*>.getStaticJsonValueGetter(): Method? = this.declaredMethods.find { method ->
+    Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonValue && it.value }
+}
 
 internal class ValueClassStaticJsonValueSerializer<T>(
     t: Class<T>,

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/JsonKeyTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/value_class/JsonKeyTest.kt
@@ -1,0 +1,54 @@
+package com.fasterxml.jackson.module.kotlin._integration.ser.value_class
+
+import com.fasterxml.jackson.annotation.JsonKey
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
+import com.fasterxml.jackson.module.kotlin.testPrettyWriter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class JsonKeyTest {
+    @JvmInline
+    value class JsonKeyGetter(val value: Int) {
+        @get:JsonKey
+        val jsonKey: String
+            get() = this.toString()
+    }
+
+    interface IJsonKeyGetter {
+        @get:JsonKey
+        val jsonKey: String
+            get() = this.toString()
+    }
+
+    @JvmInline
+    value class JsonKeyGetterImplementation(val value: Int) : IJsonKeyGetter
+
+    @JvmInline
+    value class JsonKeyGetterImplementationDisabled(val value: Int) : IJsonKeyGetter {
+        @get:JsonKey(false)
+        override val jsonKey: String
+            get() = super.jsonKey
+    }
+
+    private val writer = jacksonMapperBuilder().build().testPrettyWriter()
+
+    @Test
+    fun test() {
+        val src = mapOf(
+            JsonKeyGetter(0) to 0,
+            JsonKeyGetterImplementation(1) to 1,
+            JsonKeyGetterImplementationDisabled(2) to 2
+        )
+
+        assertEquals(
+            """
+                {
+                  "JsonKeyGetter(value=0)" : 0,
+                  "JsonKeyGetterImplementation(value=1)" : 1,
+                  "2" : 2
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(src)
+        )
+    }
+}

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/GitHub530.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_ported/test/github/GitHub530.kt
@@ -41,6 +41,13 @@ class GitHub530 {
     @JvmInline
     value class JsonValueGetterImplementation(val value: Int) : JsonValueGetter
 
+    @JvmInline
+    value class JsonValueGetterImplementationDisabled(val value: Int) : JsonValueGetter {
+        @get:JsonValue(false)
+        override val jsonValue: String
+            get() = super.jsonValue
+    }
+
     private val writer = jacksonMapperBuilder().build().testPrettyWriter()
 
     @Test
@@ -182,6 +189,29 @@ class GitHub530 {
     }
 
     @Test
+    fun jsonValueGetterImplementationDisabled() {
+        data class Data(
+            val nonNull: JsonValueGetterImplementationDisabled,
+            val nullable: JsonValueGetterImplementationDisabled?
+        )
+
+        assertEquals(
+            """
+                {
+                  "nonNull" : 0,
+                  "nullable" : 1
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(
+                Data(
+                    JsonValueGetterImplementationDisabled(0),
+                    JsonValueGetterImplementationDisabled(1)
+                )
+            )
+        )
+    }
+
+    @Test
     fun jsonValueGetterImplementationAsGenericType() {
         data class Data(
             val nonNull: JsonValueGetter,
@@ -202,19 +232,34 @@ class GitHub530 {
                 )
             )
         )
+        assertEquals(
+            """
+                {
+                  "nonNull" : 0,
+                  "nullable" : 1
+                }
+            """.trimIndent(),
+            writer.writeValueAsString(
+                Data(
+                    JsonValueGetterImplementationDisabled(0),
+                    JsonValueGetterImplementationDisabled(1)
+                )
+            )
+        )
     }
 
     @Test
     fun inCollection() {
         assertEquals(
-            "[ 0, 1, \"PropertyWithOverriddenGetter(value=2)\", \"DirectlyOverriddenGetter(value=3)\", \"JsonValueGetterImplementation(value=4)\" ]",
+            "[ 0, 1, \"PropertyWithOverriddenGetter(value=2)\", \"DirectlyOverriddenGetter(value=3)\", \"JsonValueGetterImplementation(value=4)\", 5 ]",
             writer.writeValueAsString(
                 listOf(
                     ValueParamGetterAnnotated(0),
                     ValueParamFieldAnnotated(1),
                     PropertyWithOverriddenGetter(2),
                     DirectlyOverriddenGetter(3),
-                    JsonValueGetterImplementation(4)
+                    JsonValueGetterImplementation(4),
+                    JsonValueGetterImplementationDisabled(5)
                 )
             )
         )
@@ -223,14 +268,15 @@ class GitHub530 {
     @Test
     fun inArray() {
         assertEquals(
-            "[ 0, 1, \"PropertyWithOverriddenGetter(value=2)\", \"DirectlyOverriddenGetter(value=3)\", \"JsonValueGetterImplementation(value=4)\" ]",
+            "[ 0, 1, \"PropertyWithOverriddenGetter(value=2)\", \"DirectlyOverriddenGetter(value=3)\", \"JsonValueGetterImplementation(value=4)\", 5 ]",
             writer.writeValueAsString(
                 arrayOf(
                     ValueParamGetterAnnotated(0),
                     ValueParamFieldAnnotated(1),
                     PropertyWithOverriddenGetter(2),
                     DirectlyOverriddenGetter(3),
-                    JsonValueGetterImplementation(4)
+                    JsonValueGetterImplementation(4),
+                    JsonValueGetterImplementationDisabled(5)
                 )
             )
         )


### PR DESCRIPTION
SSIA
Fixes https://github.com/FasterXML/jackson-module-kotlin/issues/536.

At the same time, the problem of the `JsonValue` flag being ignored was also fixed.