### PR TITLE
Fixed `JsonProperty` to be taken from individual members.

### DIFF
--- a/docs/FixedIssues.md
+++ b/docs/FixedIssues.md
@@ -12,6 +12,7 @@ A list of issues that have not been resolved in `jackson-module-kotlin`, but hav
 - [About the problem that property names in \`Jackson\` and definitions in \`Kotlin\` are sometimes different\. · Issue \#630](https://github.com/FasterXML/jackson-module-kotlin/issues/630)
 - [Annotation given to constructor parameters containing \`value class\` as argument does not work · Issue \#651](https://github.com/FasterXML/jackson-module-kotlin/issues/651)
 - [How to deserialize a kotlin\.ranges\.ClosedRange<T> with Jackson · Issue \#663](https://github.com/FasterXML/jackson-module-kotlin/issues/663)
+- [The parameter's \`isRequired\` is overridden by the JsonProperty granted to accessor\. · Issue \#668](https://github.com/FasterXML/jackson-module-kotlin/issues/668)
 
 ## Maybe fixed(verification required)
 - [@JsonProperty is ignored on data class properties with names starting with "is" · Issue \#237](https://github.com/FasterXML/jackson-module-kotlin/issues/237)

--- a/docs/KogeraSpecificImplementations.md
+++ b/docs/KogeraSpecificImplementations.md
@@ -22,6 +22,7 @@ In `kogera`, the specification has been revised as follows.
     - In `kogera`, the deserialization behavior is not affected by whether the argument is of type `primitive` or not.
 - The `nullToEmpty` option only affects deserialization.
     - As for `JvmField`, there was no way to distinguish between contexts, so that option affects serialization.
+- Do not override the value of a parameter by `nullability` even if `required = true` is specified for the accessor.
 
 ## Stricter visibility and privatization of some codes
 In `jackson-module-kotlin`, some code has been inadvertently released.

--- a/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/com/fasterxml/jackson/module/kotlin/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -27,6 +27,7 @@ import kotlinx.metadata.jvm.fieldSignature
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.setterSignature
 import kotlinx.metadata.jvm.signature
+import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
 import java.lang.reflect.Method
@@ -40,21 +41,24 @@ internal class KotlinPrimaryAnnotationIntrospector(
     private val nullToEmptyMap: Boolean,
     private val cache: ReflectionCache
 ) : NopAnnotationIntrospector() {
+    // region hasRequiredMarker
+
     // If JsonProperty.required is true, the behavior is clearly specified and the result is paramount.
     // Otherwise, the required is determined from the configuration and the definition on Kotlin.
-    override fun hasRequiredMarker(m: AnnotatedMember): Boolean? {
-        val byAnnotation = _findAnnotation(m, JsonProperty::class.java)?.required
-            ?.apply { if (this) return true }
-
-        return cache.getKmClass(m.member.declaringClass)?.let {
-            when (m) {
-                is AnnotatedField -> m.hasRequiredMarker(it)
-                is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it)
-                is AnnotatedParameter -> m.hasRequiredMarker(it)
-                else -> null
-            }
-        } ?: byAnnotation // If a JsonProperty is available, use it to reduce processing costs.
+    // Using this::_findAnnotation or AnnotatedMember::getAnnotation will give incorrect results
+    // because the retrieval is done from all annotations of parameters, fields, and accessors.
+    // To avoid this, the implementation retrieves from each individual member.
+    override fun hasRequiredMarker(m: AnnotatedMember): Boolean? = cache.getKmClass(m.member.declaringClass)?.let {
+        m.member
+        when (m) {
+            is AnnotatedField -> m.hasRequiredMarker(it)
+            is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it)
+            is AnnotatedParameter -> m.hasRequiredMarker(it)
+            else -> null
+        }
     }
+
+    private fun AnnotatedElement.requiredByAnnotation(): Boolean? = getAnnotation(JsonProperty::class.java)?.required
 
     // Functions that call this may return incorrect results for value classes whose value type is Collection or Map,
     // but this is a rare case and difficult to handle, so it is not supported.
@@ -65,6 +69,8 @@ internal class KotlinPrimaryAnnotationIntrospector(
     // but deserialization is preferred because there is currently no way to distinguish between contexts.
     private fun AnnotatedField.hasRequiredMarker(kmClass: KmClass): Boolean? {
         val member = annotated
+        val byAnnotation = member.requiredByAnnotation().apply { if (this == true) return true }
+
         val fieldSignature = member.toSignature()
 
         // Direct access to `AnnotatedField` is only performed if there is no accessor (defined as JvmField),
@@ -76,11 +82,14 @@ internal class KotlinPrimaryAnnotationIntrospector(
             // https://youtrack.jetbrains.com/issue/KT-6519
             ?.takeIf { it.getterSignature == null }
             ?.let { !(it.returnType.isNullable() || type.hasDefaultEmptyValue()) }
+            ?: byAnnotation
     }
 
     private fun KmProperty.isRequiredByNullability(): Boolean = !this.returnType.isNullable()
 
     private fun AnnotatedMethod.getRequiredMarkerFromCorrespondingAccessor(kmClass: KmClass): Boolean? {
+        val byAnnotation = member.requiredByAnnotation().apply { if (this == true) return true }
+
         // false if setter and nullToEmpty option is specified
         if (parameterCount == 1 && this.getParameter(0).type.hasDefaultEmptyValue()) return false
 
@@ -88,13 +97,20 @@ internal class KotlinPrimaryAnnotationIntrospector(
         return kmClass.properties
             .find { it.getterSignature == memberSignature || it.setterSignature == memberSignature }
             ?.isRequiredByNullability()
+            ?: byAnnotation
     }
 
     private fun AnnotatedParameter.hasRequiredMarker(kmClass: KmClass): Boolean? {
         val paramDef = when (val member = member) {
-            is Constructor<*> -> kmClass.findKmConstructor(member)
-                ?.let { it.valueParameters[index] }
+            is Constructor<*> -> {
+                member.parameters[index].requiredByAnnotation().apply { if (this == true) return true }
+
+                kmClass.findKmConstructor(member)
+                    ?.let { it.valueParameters[index] }
+            }
             is Method -> {
+                member.parameters[index].requiredByAnnotation().apply { if (this == true) return true }
+
                 val signature = member.toSignature()
                 kmClass.functions.find { it.signature == signature }
                     ?.let { it.valueParameters[index] }
@@ -113,6 +129,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
             else -> true
         }
     }
+    // endregion
 
     /**
      * Subclasses can be detected automatically for sealed classes, since all possible subclasses are known

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/HasRequiredMarkerTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/deser/HasRequiredMarkerTest.kt
@@ -160,4 +160,23 @@ class HasRequiredMarkerTest {
         assertTrue(desc.isRequired("mapProp"))
         assertTrue(desc.isRequired("mapField"))
     }
+
+    data class AffectByAccessor(
+        @get:JsonProperty(required = true)
+        @field:JsonProperty(required = true)
+        @set:JsonProperty(required = true)
+        var a: String?
+    ) {
+        @get:JsonProperty(required = true)
+        @field:JsonProperty(required = true)
+        var b: String? = null
+    }
+
+    @Test
+    fun affectByAccessorTest() {
+        val desc = defaultMapper.introspectDeser<AffectByAccessor>()
+
+        assertFalse(desc.isRequired("a"))
+        assertFalse(desc.isRequired("b"))
+    }
 }

--- a/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/HasRequiredMarkerTest.kt
+++ b/src/test/kotlin/com/fasterxml/jackson/module/kotlin/_integration/ser/HasRequiredMarkerTest.kt
@@ -86,4 +86,23 @@ class HasRequiredMarkerTest {
             "KotlinPrimaryAnnotationIntrospector::AnnotatedField.hasRequiredMarker fixed"
         )
     }
+
+    data class AffectByAccessor(
+        @param:JsonProperty(required = true)
+        @field:JsonProperty(required = true)
+        @set:JsonProperty(required = true)
+        var a: String?
+    ) {
+        @set:JsonProperty(required = true)
+        @field:JsonProperty(required = true)
+        var b: String? = null
+    }
+
+    @Test
+    fun affectByAccessorTest() {
+        val desc = mapper.introspectSer<AffectByAccessor>()
+
+        assertFalse(desc.isRequired("a"))
+        assertFalse(desc.isRequired("b"))
+    }
 }


### PR DESCRIPTION
For example, because the annotations given to the getter affected the parameters.

related to https://github.com/FasterXML/jackson-module-kotlin/issues/668