### PR TITLE
Fix javadoc task setting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,10 @@ public val kogeraVersion: Version = VersionUtil.parseVersion("$version", "$group
     val javadocJar = named<Jar>("javadocJar") {
         from(named("dokkaJavadoc"))
     }
+    // The project currently has no Java files to publish, and the javadoc task is disabled to avoid errors.
+    javadoc {
+        isEnabled = false
+    }
 }
 
 publishing {


### PR DESCRIPTION
I published to `JitPack` with #108 and got an error as `javadoc: error - No public or protected classes found to document.`.
https://jitpack.io/com/github/ProjectMapK/jackson-module-kogera/develop-018053686a-1/build.log