### PR TITLE
Modified to go through its own class instead of directly referencing KmClass.

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -4,13 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
-import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassMetadata
-import kotlinx.metadata.jvm.signature
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
@@ -103,26 +101,6 @@ internal fun String.reconstructClass(): Class<*> {
 
 internal fun KmType.reconstructClassOrNull(): Class<*>? = (classifier as? KmClassifier.Class)
     ?.let { kotlin.runCatching { it.name.reconstructClass() }.getOrNull() }
-
-internal fun KmClass.findKmConstructor(constructor: Constructor<*>): KmConstructor? {
-    val descHead = constructor.parameterTypes.toDescBuilder()
-    val desc = CharArray(descHead.length + 1).apply {
-        descHead.getChars(0, descHead.length, this, 0)
-        this[this.lastIndex] = 'V'
-    }.let { String(it) }
-
-    // Only constructors that take a value class as an argument have a DefaultConstructorMarker on the Signature.
-    val valueDesc = descHead
-        .deleteCharAt(descHead.length - 1)
-        .append("Lkotlin/jvm/internal/DefaultConstructorMarker;)V")
-        .toString()
-
-    // Constructors always have the same name, so only desc is compared
-    return constructors.find {
-        val targetDesc = it.signature?.desc
-        targetDesc == desc || targetDesc == valueDesc
-    }
-}
 
 internal fun KmType.isNullable(): Boolean = Flag.Type.IS_NULLABLE(this.flags)
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -5,13 +5,11 @@ import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmConstructor
-import kotlinx.metadata.KmProperty
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassMetadata
-import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Constructor
@@ -124,11 +122,6 @@ internal fun KmClass.findKmConstructor(constructor: Constructor<*>): KmConstruct
         val targetDesc = it.signature?.desc
         targetDesc == desc || targetDesc == valueDesc
     }
-}
-
-internal fun KmClass.findPropertyByGetter(getter: Method): KmProperty? {
-    val signature = getter.toSignature()
-    return properties.find { it.getterSignature == signature }
 }
 
 internal fun KmType.isNullable(): Boolean = Flag.Type.IS_NULLABLE(this.flags)

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -2,6 +2,7 @@ package io.github.projectmapk.jackson.module.kogera
 
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmConstructor
+import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.signature
@@ -12,6 +13,7 @@ import java.lang.reflect.Method
 internal class JmClass(val kmClass: KmClass) {
     val constructors: List<KmConstructor> = kmClass.constructors
     val properties: List<KmProperty> = kmClass.properties
+    private val functions: List<KmFunction> = kmClass.functions
 
     fun findKmConstructor(constructor: Constructor<*>): KmConstructor? {
         val descHead = constructor.parameterTypes.toDescBuilder()
@@ -36,6 +38,11 @@ internal class JmClass(val kmClass: KmClass) {
     fun findPropertyByGetter(getter: Method): KmProperty? {
         val signature = getter.toSignature()
         return properties.find { it.getterSignature == signature }
+    }
+
+    fun findFunctionByMethod(method: Method): KmFunction? {
+        val signature = method.toSignature()
+        return functions.find { it.signature == signature }
     }
 
     companion object {

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -2,10 +2,17 @@ package io.github.projectmapk.jackson.module.kogera
 
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmProperty
+import kotlinx.metadata.jvm.getterSignature
+import java.lang.reflect.Method
 
 // Jackson Metadata Class
 internal class JmClass(val kmClass: KmClass) {
     val properties: List<KmProperty> = kmClass.properties
+
+    fun findPropertyByGetter(getter: Method): KmProperty? {
+        val signature = getter.toSignature()
+        return properties.find { it.getterSignature == signature }
+    }
 
     companion object {
         fun createOrNull(clazz: Class<*>): JmClass? = clazz.toKmClass()?.let { JmClass(it) }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -1,13 +1,37 @@
 package io.github.projectmapk.jackson.module.kogera
 
 import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.signature
+import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
 // Jackson Metadata Class
 internal class JmClass(val kmClass: KmClass) {
+    val constructors: List<KmConstructor> = kmClass.constructors
     val properties: List<KmProperty> = kmClass.properties
+
+    fun findKmConstructor(constructor: Constructor<*>): KmConstructor? {
+        val descHead = constructor.parameterTypes.toDescBuilder()
+        val desc = CharArray(descHead.length + 1).apply {
+            descHead.getChars(0, descHead.length, this, 0)
+            this[this.lastIndex] = 'V'
+        }.let { String(it) }
+
+        // Only constructors that take a value class as an argument have a DefaultConstructorMarker on the Signature.
+        val valueDesc = descHead
+            .deleteCharAt(descHead.length - 1)
+            .append("Lkotlin/jvm/internal/DefaultConstructorMarker;)V")
+            .toString()
+
+        // Constructors always have the same name, so only desc is compared
+        return constructors.find {
+            val targetDesc = it.signature?.desc
+            targetDesc == desc || targetDesc == valueDesc
+        }
+    }
 
     fun findPropertyByGetter(getter: Method): KmProperty? {
         val signature = getter.toSignature()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -1,5 +1,6 @@
 package io.github.projectmapk.jackson.module.kogera
 
+import kotlinx.metadata.ClassName
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmFunction
@@ -14,6 +15,7 @@ internal class JmClass(val kmClass: KmClass) {
     val constructors: List<KmConstructor> = kmClass.constructors
     val properties: List<KmProperty> = kmClass.properties
     private val functions: List<KmFunction> = kmClass.functions
+    val sealedSubclasses: List<ClassName> = kmClass.sealedSubclasses
 
     fun findKmConstructor(constructor: Constructor<*>): KmConstructor? {
         val descHead = constructor.parameterTypes.toDescBuilder()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -1,9 +1,12 @@
 package io.github.projectmapk.jackson.module.kogera
 
 import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmProperty
 
 // Jackson Metadata Class
 internal class JmClass(val kmClass: KmClass) {
+    val properties: List<KmProperty> = kmClass.properties
+
     companion object {
         fun createOrNull(clazz: Class<*>): JmClass? = clazz.toKmClass()?.let { JmClass(it) }
     }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -57,8 +57,14 @@ internal class JmClass(
         companionObject: String
     ) {
         private val companionField: Field = declaringClass.getDeclaredField(companionObject)
-        private val companionObjectClass: Class<*> = companionField.type
-        private val kmClass: KmClass by lazy { companionObjectClass.toKmClass()!! }
+        val type: Class<*> = companionField.type
+        val isAccessible: Boolean = companionField.isAccessible
+        private val kmClass: KmClass by lazy { type.toKmClass()!! }
+        val instance: Any by lazy {
+            // To prevent the call from failing, save the initial value and then rewrite the flag.
+            if (!companionField.isAccessible) companionField.isAccessible = true
+            companionField.get(null)
+        }
 
         fun findFunctionByMethod(method: Method): KmFunction? {
             val signature = method.toSignature()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -14,13 +14,14 @@ import java.lang.reflect.Method
 // Jackson Metadata Class
 internal class JmClass(
     private val clazz: Class<*>,
-    val kmClass: KmClass
+    kmClass: KmClass
 ) {
     val constructors: List<KmConstructor> = kmClass.constructors
     val properties: List<KmProperty> = kmClass.properties
     private val functions: List<KmFunction> = kmClass.functions
     val sealedSubclasses: List<ClassName> = kmClass.sealedSubclasses
-    val companion: CompanionObject? by lazy { CompanionObject.createOrNull(this) }
+    private val companionPropName: String? = kmClass.companionObject
+    val companion: CompanionObject? by lazy { companionPropName?.let { CompanionObject(clazz, it) } }
 
     fun findKmConstructor(constructor: Constructor<*>): KmConstructor? {
         val descHead = constructor.parameterTypes.toDescBuilder()
@@ -69,11 +70,6 @@ internal class JmClass(
         fun findFunctionByMethod(method: Method): KmFunction? {
             val signature = method.toSignature()
             return kmClass.functions.find { it.signature == signature }
-        }
-
-        companion object {
-            fun createOrNull(jmClass: JmClass): CompanionObject? = jmClass.kmClass.companionObject
-                ?.let { CompanionObject(jmClass.clazz, it) }
         }
     }
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -1,0 +1,10 @@
+package io.github.projectmapk.jackson.module.kogera
+
+import kotlinx.metadata.KmClass
+
+// Jackson Metadata Class
+internal class JmClass(val kmClass: KmClass) {
+    companion object {
+        fun createOrNull(clazz: Class<*>): JmClass? = clazz.toKmClass()?.let { JmClass(it) }
+    }
+}

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -66,7 +66,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             creatorCache.get(creator)
                 ?: run {
                     getJmClass(creator.declaringClass)?.let {
-                        val value = ConstructorValueCreator(creator, it.kmClass)
+                        val value = ConstructorValueCreator(creator, it)
                         creatorCache.putIfAbsent(creator, value) ?: value
                     }
                 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -94,7 +94,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             // TODO: Verify the case where a value class encompasses another value class.
             if (this.returnType.isUnboxableValueClass()) return null
         }
-        val kotlinProperty = getJmClass(getter.declaringClass)?.kmClass?.findPropertyByGetter(getter)
+        val kotlinProperty = getJmClass(getter.declaringClass)?.findPropertyByGetter(getter)
 
         // Since there was no way to directly determine whether returnType is a value class or not,
         // Class is restored and processed.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -6,7 +6,6 @@ import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.crea
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.MethodValueCreator
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.ValueCreator
 import io.github.projectmapk.jackson.module.kogera.ser.ValueClassBoxConverter
-import kotlinx.metadata.KmClass
 import java.io.Serializable
 import java.lang.reflect.Constructor
 import java.lang.reflect.Executable
@@ -21,7 +20,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     }
 
     // This cache is used for both serialization and deserialization, so reserve a larger size from the start.
-    private val classCache = LRUMap<Class<*>, Optional<KmClass>>(reflectionCacheSize, reflectionCacheSize)
+    private val classCache = LRUMap<Class<*>, Optional<JmClass>>(reflectionCacheSize, reflectionCacheSize)
     private val creatorCache: LRUMap<Executable, ValueCreator<*>>
 
     // Initial size is 0 because the value class is not always used
@@ -48,13 +47,13 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         creatorCache = LRUMap(initialEntries, reflectionCacheSize)
     }
 
-    fun getJmClass(clazz: Class<*>): KmClass? {
+    fun getJmClass(clazz: Class<*>): JmClass? {
         val optional = classCache.get(clazz)
 
         return if (optional != null) {
             optional
         } else {
-            val value = Optional.ofNullable(clazz.toKmClass())
+            val value = Optional.ofNullable(JmClass.createOrNull(clazz))
             (classCache.putIfAbsent(clazz, value) ?: value)
         }.orElse(null)
     }
@@ -67,7 +66,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             creatorCache.get(creator)
                 ?: run {
                     getJmClass(creator.declaringClass)?.let {
-                        val value = ConstructorValueCreator(creator, it)
+                        val value = ConstructorValueCreator(creator, it.kmClass)
                         creatorCache.putIfAbsent(creator, value) ?: value
                     }
                 }
@@ -77,7 +76,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             creatorCache.get(creator)
                 ?: run {
                     getJmClass(creator.declaringClass)?.let {
-                        val value = MethodValueCreator<Any?>(creator, it)
+                        val value = MethodValueCreator<Any?>(creator, it.kmClass)
                         creatorCache.putIfAbsent(creator, value) ?: value
                     }
                 }
@@ -95,7 +94,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             // TODO: Verify the case where a value class encompasses another value class.
             if (this.returnType.isUnboxableValueClass()) return null
         }
-        val kotlinProperty = getJmClass(getter.declaringClass)?.findPropertyByGetter(getter)
+        val kotlinProperty = getJmClass(getter.declaringClass)?.kmClass?.findPropertyByGetter(getter)
 
         // Since there was no way to directly determine whether returnType is a value class or not,
         // Class is restored and processed.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -76,7 +76,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             creatorCache.get(creator)
                 ?: run {
                     getJmClass(creator.declaringClass)?.let {
-                        val value = MethodValueCreator<Any?>(creator, it.kmClass)
+                        val value = MethodValueCreator<Any?>(creator, it)
                         creatorCache.putIfAbsent(creator, value) ?: value
                     }
                 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -48,7 +48,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         creatorCache = LRUMap(initialEntries, reflectionCacheSize)
     }
 
-    fun getKmClass(clazz: Class<*>): KmClass? {
+    fun getJmClass(clazz: Class<*>): KmClass? {
         val optional = classCache.get(clazz)
 
         return if (optional != null) {
@@ -66,7 +66,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         is Constructor<*> -> {
             creatorCache.get(creator)
                 ?: run {
-                    getKmClass(creator.declaringClass)?.let {
+                    getJmClass(creator.declaringClass)?.let {
                         val value = ConstructorValueCreator(creator, it)
                         creatorCache.putIfAbsent(creator, value) ?: value
                     }
@@ -76,7 +76,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         is Method -> {
             creatorCache.get(creator)
                 ?: run {
-                    getKmClass(creator.declaringClass)?.let {
+                    getJmClass(creator.declaringClass)?.let {
                         val value = MethodValueCreator<Any?>(creator, it)
                         creatorCache.putIfAbsent(creator, value) ?: value
                     }
@@ -95,7 +95,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             // TODO: Verify the case where a value class encompasses another value class.
             if (this.returnType.isUnboxableValueClass()) return null
         }
-        val kotlinProperty = getKmClass(getter.declaringClass)?.findPropertyByGetter(getter)
+        val kotlinProperty = getJmClass(getter.declaringClass)?.findPropertyByGetter(getter)
 
         // Since there was no way to directly determine whether returnType is a value class or not,
         // Class is restored and processed.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -53,13 +53,8 @@ internal class KotlinFallbackAnnotationIntrospector(
         is Method ->
             owner.takeIf { _ -> Modifier.isStatic(owner.modifiers) }
                 ?.let { _ ->
-                    val companion = cache.getJmClass(param.declaringClass)?.kmClass?.companionObject ?: return@let null
-                    val companionKmClass = owner.declaringClass.getDeclaredField(companion)
-                        .type
-                        .let { cache.getJmClass(it) }!!
-                    val signature = owner.toSignature()
-
-                    companionKmClass.kmClass.functions.find { it.signature == signature }?.valueParameters
+                    val companion = cache.getJmClass(param.declaringClass)?.companion ?: return@let null
+                    companion.findFunctionByMethod(owner)?.valueParameters
                 }
         else -> null
     }?.let { it[param.index].name }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -18,7 +18,6 @@ import io.github.projectmapk.jackson.module.kogera.deser.MapValueStrictNullCheck
 import io.github.projectmapk.jackson.module.kogera.deser.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.ValueParameter
 import io.github.projectmapk.jackson.module.kogera.findKmConstructor
-import io.github.projectmapk.jackson.module.kogera.findPropertyByGetter
 import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
@@ -42,7 +41,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     // since 2.4
     override fun findImplicitPropertyName(member: AnnotatedMember): String? = when (member) {
         is AnnotatedMethod -> if (member.parameterCount == 0) {
-            cache.getJmClass(member.declaringClass)?.kmClass?.findPropertyByGetter(member.annotated)?.name
+            cache.getJmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
         } else {
             null
         }
@@ -73,7 +72,7 @@ internal class KotlinFallbackAnnotationIntrospector(
 
             // By returning an illegal JsonProperty.Access, it is effectively ignore.
             when (method.parameters.size) {
-                0 -> JsonProperty.Access.WRITE_ONLY.takeIf { jmClass.kmClass.findPropertyByGetter(method) == null }
+                0 -> JsonProperty.Access.WRITE_ONLY.takeIf { jmClass.findPropertyByGetter(method) == null }
                 1 -> {
                     val signature = method.toSignature()
                     JsonProperty.Access.READ_ONLY.takeIf { jmClass.properties.none { it.setterSignature == signature } }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -42,7 +42,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     // since 2.4
     override fun findImplicitPropertyName(member: AnnotatedMember): String? = when (member) {
         is AnnotatedMethod -> if (member.parameterCount == 0) {
-            cache.getKmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
+            cache.getJmClass(member.declaringClass)?.findPropertyByGetter(member.annotated)?.name
         } else {
             null
         }
@@ -51,14 +51,14 @@ internal class KotlinFallbackAnnotationIntrospector(
     }
 
     private fun findKotlinParameterName(param: AnnotatedParameter): String? = when (val owner = param.owner.member) {
-        is Constructor<*> -> cache.getKmClass(param.declaringClass)?.findKmConstructor(owner)?.valueParameters
+        is Constructor<*> -> cache.getJmClass(param.declaringClass)?.findKmConstructor(owner)?.valueParameters
         is Method ->
             owner.takeIf { _ -> Modifier.isStatic(owner.modifiers) }
                 ?.let { _ ->
-                    val companion = cache.getKmClass(param.declaringClass)?.companionObject ?: return@let null
+                    val companion = cache.getJmClass(param.declaringClass)?.companionObject ?: return@let null
                     val companionKmClass = owner.declaringClass.getDeclaredField(companion)
                         .type
-                        .let { cache.getKmClass(it) }!!
+                        .let { cache.getJmClass(it) }!!
                     val signature = owner.toSignature()
 
                     companionKmClass.functions.find { it.signature == signature }?.valueParameters
@@ -68,15 +68,15 @@ internal class KotlinFallbackAnnotationIntrospector(
 
     // If it is not a property on Kotlin, it is not used to ser/deserialization
     override fun findPropertyAccess(ann: Annotated): JsonProperty.Access? = (ann as? AnnotatedMethod)?.let { _ ->
-        cache.getKmClass(ann.declaringClass)?.let { kmClass ->
+        cache.getJmClass(ann.declaringClass)?.let { jmClass ->
             val method = ann.annotated
 
             // By returning an illegal JsonProperty.Access, it is effectively ignore.
             when (method.parameters.size) {
-                0 -> JsonProperty.Access.WRITE_ONLY.takeIf { kmClass.findPropertyByGetter(method) == null }
+                0 -> JsonProperty.Access.WRITE_ONLY.takeIf { jmClass.findPropertyByGetter(method) == null }
                 1 -> {
                     val signature = method.toSignature()
-                    JsonProperty.Access.READ_ONLY.takeIf { kmClass.properties.none { it.setterSignature == signature } }
+                    JsonProperty.Access.READ_ONLY.takeIf { jmClass.properties.none { it.setterSignature == signature } }
                 }
                 else -> null
             }
@@ -115,7 +115,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     // Determine if the unbox result of value class is nullable
     // @see findNullSerializer
     private fun Class<*>.requireRebox(): Boolean =
-        cache.getKmClass(this)!!.properties.first { it.fieldSignature != null }.returnType.isNullable()
+        cache.getJmClass(this)!!.properties.first { it.fieldSignature != null }.returnType.isNullable()
 
     // Perform proper serialization even if the value wrapped by the value class is null.
     // If value is a non-null object type, it must not be reboxing.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -17,7 +17,6 @@ import io.github.projectmapk.jackson.module.kogera.deser.CollectionValueStrictNu
 import io.github.projectmapk.jackson.module.kogera.deser.MapValueStrictNullChecksConverter
 import io.github.projectmapk.jackson.module.kogera.deser.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.ValueParameter
-import io.github.projectmapk.jackson.module.kogera.findKmConstructor
 import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
@@ -50,7 +49,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     }
 
     private fun findKotlinParameterName(param: AnnotatedParameter): String? = when (val owner = param.owner.member) {
-        is Constructor<*> -> cache.getJmClass(param.declaringClass)?.kmClass?.findKmConstructor(owner)?.valueParameters
+        is Constructor<*> -> cache.getJmClass(param.declaringClass)?.findKmConstructor(owner)?.valueParameters
         is Method ->
             owner.takeIf { _ -> Modifier.isStatic(owner.modifiers) }
                 ?.let { _ ->

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -76,7 +76,7 @@ internal class KotlinFallbackAnnotationIntrospector(
                 0 -> JsonProperty.Access.WRITE_ONLY.takeIf { jmClass.kmClass.findPropertyByGetter(method) == null }
                 1 -> {
                     val signature = method.toSignature()
-                    JsonProperty.Access.READ_ONLY.takeIf { jmClass.kmClass.properties.none { it.setterSignature == signature } }
+                    JsonProperty.Access.READ_ONLY.takeIf { jmClass.properties.none { it.setterSignature == signature } }
                 }
                 else -> null
             }
@@ -115,7 +115,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     // Determine if the unbox result of value class is nullable
     // @see findNullSerializer
     private fun Class<*>.requireRebox(): Boolean =
-        cache.getJmClass(this)!!.kmClass.properties.first { it.fieldSignature != null }.returnType.isNullable()
+        cache.getJmClass(this)!!.properties.first { it.fieldSignature != null }.returnType.isNullable()
 
     // Perform proper serialization even if the value wrapped by the value class is null.
     // If value is a non-null object type, it must not be reboxing.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -116,7 +116,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
     // The definition location was not changed from kotlin-module because
     // the result was the same whether it was defined in Primary or Fallback.
     override fun findSubtypes(a: Annotated): List<NamedType>? = cache.getJmClass(a.rawType)?.let { jmClass ->
-        jmClass.kmClass.sealedSubclasses.map { NamedType(it.reconstructClass()) }.ifEmpty { null }
+        jmClass.sealedSubclasses.map { NamedType(it.reconstructClass()) }.ifEmpty { null }
     }
 
     // Return Mode.DEFAULT if ann is a Primary Constructor and the condition is satisfied.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -92,15 +92,11 @@ internal class KotlinPrimaryAnnotationIntrospector(
 
     private fun AnnotatedParameter.hasRequiredMarker(jmClass: JmClass): Boolean? {
         val paramDef = when (val member = member) {
-            is Constructor<*> -> jmClass.findKmConstructor(member)
-                ?.let { it.valueParameters[index] }
-            is Method -> {
-                val signature = member.toSignature()
-                jmClass.kmClass.functions.find { it.signature == signature }
-                    ?.let { it.valueParameters[index] }
-            }
+            is Constructor<*> -> jmClass.findKmConstructor(member)?.valueParameters
+
+            is Method -> jmClass.findFunctionByMethod(member)?.valueParameters
             else -> null
-        } ?: return null // Return null if function on Kotlin cannot be determined
+        }?.let { it[index] } ?: return null // Return null if function on Kotlin cannot be determined
 
         // non required if...
         return when {

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -48,9 +48,9 @@ internal class KotlinPrimaryAnnotationIntrospector(
 
         return cache.getJmClass(m.member.declaringClass)?.let {
             when (m) {
-                is AnnotatedField -> m.hasRequiredMarker(it)
-                is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it)
-                is AnnotatedParameter -> m.hasRequiredMarker(it)
+                is AnnotatedField -> m.hasRequiredMarker(it.kmClass)
+                is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it.kmClass)
+                is AnnotatedParameter -> m.hasRequiredMarker(it.kmClass)
                 else -> null
             }
         } ?: byAnnotation // If a JsonProperty is available, use it to reduce processing costs.
@@ -121,7 +121,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
     // The definition location was not changed from kotlin-module because
     // the result was the same whether it was defined in Primary or Fallback.
     override fun findSubtypes(a: Annotated): List<NamedType>? = cache.getJmClass(a.rawType)?.let { jmClass ->
-        jmClass.sealedSubclasses.map { NamedType(it.reconstructClass()) }.ifEmpty { null }
+        jmClass.kmClass.sealedSubclasses.map { NamedType(it.reconstructClass()) }.ifEmpty { null }
     }
 
     // Return Mode.DEFAULT if ann is a Primary Constructor and the condition is satisfied.
@@ -140,7 +140,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
             ?: return null
 
         return JsonCreator.Mode.DEFAULT
-            .takeIf { ann.annotated.isPrimarilyConstructorOf(kmClass) && !hasCreator(declaringClass, kmClass) }
+            .takeIf { ann.annotated.isPrimarilyConstructorOf(kmClass.kmClass) && !hasCreator(declaringClass, kmClass.kmClass) }
     }
 }
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -46,7 +46,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
         val byAnnotation = _findAnnotation(m, JsonProperty::class.java)?.required
             ?.apply { if (this) return true }
 
-        return cache.getKmClass(m.member.declaringClass)?.let {
+        return cache.getJmClass(m.member.declaringClass)?.let {
             when (m) {
                 is AnnotatedField -> m.hasRequiredMarker(it)
                 is AnnotatedMethod -> m.getRequiredMarkerFromCorrespondingAccessor(it)
@@ -120,8 +120,8 @@ internal class KotlinPrimaryAnnotationIntrospector(
      */
     // The definition location was not changed from kotlin-module because
     // the result was the same whether it was defined in Primary or Fallback.
-    override fun findSubtypes(a: Annotated): List<NamedType>? = cache.getKmClass(a.rawType)?.let { kmClass ->
-        kmClass.sealedSubclasses.map { NamedType(it.reconstructClass()) }.ifEmpty { null }
+    override fun findSubtypes(a: Annotated): List<NamedType>? = cache.getJmClass(a.rawType)?.let { jmClass ->
+        jmClass.sealedSubclasses.map { NamedType(it.reconstructClass()) }.ifEmpty { null }
     }
 
     // Return Mode.DEFAULT if ann is a Primary Constructor and the condition is satisfied.
@@ -136,7 +136,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
         val declaringClass = ann.declaringClass
         val kmClass = declaringClass
             ?.takeIf { !it.isEnum }
-            ?.let { cache.getKmClass(it) }
+            ?.let { cache.getJmClass(it) }
             ?: return null
 
         return JsonCreator.Mode.DEFAULT

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -136,7 +136,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
             ?: return null
 
         return JsonCreator.Mode.DEFAULT
-            .takeIf { ann.annotated.isPrimarilyConstructorOf(jmClass) && !hasCreator(declaringClass, jmClass.kmClass) }
+            .takeIf { ann.annotated.isPrimarilyConstructorOf(jmClass) && !hasCreator(declaringClass, jmClass) }
     }
 }
 
@@ -154,8 +154,8 @@ private fun isPossibleSingleString(
     kotlinParams[0].let { it.name !in propertyNames && it.type.classifier.isString() } &&
     javaFunction.parameters[0].annotations.none { it is JsonProperty }
 
-private fun hasCreatorConstructor(clazz: Class<*>, kmClass: KmClass, propertyNames: Set<String>): Boolean {
-    val kmConstructorMap = kmClass.constructors.associateBy { it.signature?.desc }
+private fun hasCreatorConstructor(clazz: Class<*>, jmClass: JmClass, propertyNames: Set<String>): Boolean {
+    val kmConstructorMap = jmClass.constructors.associateBy { it.signature?.desc }
 
     return clazz.constructors.any { constructor ->
         val kmConstructor = kmConstructorMap[constructor.toSignature().desc] ?: return@any false
@@ -170,7 +170,7 @@ private fun hasCreatorConstructor(clazz: Class<*>, kmClass: KmClass, propertyNam
 private fun hasCreatorFunction(clazz: Class<*>): Boolean = clazz.declaredMethods
     .any { Modifier.isStatic(it.modifiers) && it.hasCreatorAnnotation() }
 
-private fun hasCreator(clazz: Class<*>, kmClass: KmClass): Boolean {
-    val propertyNames = kmClass.properties.map { it.name }.toSet()
-    return hasCreatorConstructor(clazz, kmClass, propertyNames) || hasCreatorFunction(clazz)
+private fun hasCreator(clazz: Class<*>, jmClass: JmClass): Boolean {
+    val propertyNames = jmClass.properties.map { it.name }.toSet()
+    return hasCreatorConstructor(clazz, jmClass, propertyNames) || hasCreatorFunction(clazz)
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -9,12 +9,12 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import io.github.projectmapk.jackson.module.kogera.JmClass
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.hasCreatorAnnotation
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.toSignature
 import kotlinx.metadata.Flag
-import kotlinx.metadata.KmClass
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -101,9 +101,9 @@ private fun invalidCreatorMessage(m: Method): String =
         "please fix it or use JsonDeserializer.\n" +
         "Detected: ${m.parameters.joinToString(prefix = "${m.name}(", separator = ", ", postfix = ")") { it.name }}"
 
-private fun findValueCreator(type: JavaType, clazz: Class<*>, kmClass: KmClass): Method? {
+private fun findValueCreator(type: JavaType, clazz: Class<*>, jmClass: JmClass): Method? {
     val primaryKmConstructorSignature =
-        kmClass.constructors.first { !Flag.Constructor.IS_SECONDARY(it.flags) }.signature
+        jmClass.constructors.first { !Flag.Constructor.IS_SECONDARY(it.flags) }.signature
     var primaryConstructor: Method? = null
 
     clazz.declaredMethods.forEach { method ->
@@ -142,7 +142,7 @@ internal class KotlinDeserializers(private val cache: ReflectionCache) : Deseria
             rawClass == UShort::class.java -> UShortDeserializer
             rawClass == UInt::class.java -> UIntDeserializer
             rawClass == ULong::class.java -> ULongDeserializer
-            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!.kmClass)
+            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)
                 ?.let { ValueClassBoxDeserializer(it, rawClass) }
             else -> null
         }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -142,7 +142,7 @@ internal class KotlinDeserializers(private val cache: ReflectionCache) : Deseria
             rawClass == UShort::class.java -> UShortDeserializer
             rawClass == UInt::class.java -> UIntDeserializer
             rawClass == ULong::class.java -> ULongDeserializer
-            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getKmClass(rawClass)!!)
+            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)
                 ?.let { ValueClassBoxDeserializer(it, rawClass) }
             else -> null
         }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -142,7 +142,7 @@ internal class KotlinDeserializers(private val cache: ReflectionCache) : Deseria
             rawClass == UShort::class.java -> UShortDeserializer
             rawClass == UInt::class.java -> UIntDeserializer
             rawClass == ULong::class.java -> ULongDeserializer
-            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)
+            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!.kmClass)
                 ?.let { ValueClassBoxDeserializer(it, rawClass) }
             else -> null
         }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/value_instantiator/creator/ConstructorValueCreator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/value_instantiator/creator/ConstructorValueCreator.kt
@@ -1,19 +1,18 @@
 package io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator
 
+import io.github.projectmapk.jackson.module.kogera.JmClass
 import io.github.projectmapk.jackson.module.kogera.call
 import io.github.projectmapk.jackson.module.kogera.defaultConstructorMarker
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.argument_bucket.ArgumentBucket
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.argument_bucket.BucketGenerator
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.calcMaskSize
-import io.github.projectmapk.jackson.module.kogera.findKmConstructor
 import io.github.projectmapk.jackson.module.kogera.getDeclaredConstructorBy
 import io.github.projectmapk.jackson.module.kogera.hasVarargParam
-import kotlinx.metadata.KmClass
 import java.lang.reflect.Constructor
 
 internal class ConstructorValueCreator<T : Any>(
     private val constructor: Constructor<T>,
-    declaringKmClass: KmClass
+    declaringJmClass: JmClass
 ) : ValueCreator<T>() {
     private val declaringClass: Class<T> = constructor.declaringClass
 
@@ -26,7 +25,7 @@ internal class ConstructorValueCreator<T : Any>(
         // To prevent the call from failing, save the initial value and then rewrite the flag.
         if (!isAccessible) constructor.isAccessible = true
 
-        val constructorParameters = declaringKmClass.findKmConstructor(constructor)!!.valueParameters
+        val constructorParameters = declaringJmClass.findKmConstructor(constructor)!!.valueParameters
 
         valueParameters = constructorParameters.map { ValueParameter(it) }
         bucketGenerator = BucketGenerator(constructor.parameterTypes.asList(), constructorParameters.hasVarargParam())

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/value_instantiator/creator/MethodValueCreator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/value_instantiator/creator/MethodValueCreator.kt
@@ -1,60 +1,39 @@
 package io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator
 
+import io.github.projectmapk.jackson.module.kogera.JmClass
 import io.github.projectmapk.jackson.module.kogera.call
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.argument_bucket.ArgumentBucket
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.argument_bucket.BucketGenerator
 import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.calcMaskSize
 import io.github.projectmapk.jackson.module.kogera.getDeclaredMethodBy
 import io.github.projectmapk.jackson.module.kogera.hasVarargParam
-import io.github.projectmapk.jackson.module.kogera.toKmClass
-import io.github.projectmapk.jackson.module.kogera.toSignature
-import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmFunction
-import kotlinx.metadata.jvm.signature
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 
-internal class MethodValueCreator<T>(private val method: Method, declaringKmClass: KmClass) : ValueCreator<T>() {
-    // companion object is always present in the case of a factory function
-    private val companionField: Field
-    private val companionObjectClass: Class<*>
-
-    override val isAccessible: Boolean
+internal class MethodValueCreator<T>(private val method: Method, declaringJmClass: JmClass) : ValueCreator<T>() {
+    private val companion: JmClass.CompanionObject = declaringJmClass.companion!!
+    override val isAccessible: Boolean = method.isAccessible && companion.isAccessible
     override val callableName: String = method.name
     override val valueParameters: List<ValueParameter>
     override val bucketGenerator: BucketGenerator
 
     init {
-        val declaringClass = method.declaringClass
-        companionField = declaringClass.getDeclaredField(declaringKmClass.companionObject!!)
-
-        // region: about accessibility
-        isAccessible = method.isAccessible && companionField.isAccessible
-
         // To prevent the call from failing, save the initial value and then rewrite the flag.
         if (!method.isAccessible) method.isAccessible = true
-        if (!companionField.isAccessible) companionField.isAccessible = true
-        // endregion
 
-        // region: read kotlin metadata information
-        companionObjectClass = companionField.type
-        val companionKmClass: KmClass = companionObjectClass.toKmClass()!!
-        val kmFunction: KmFunction = run {
-            val signature = method.toSignature()
-            companionKmClass.functions.first { signature == it.signature }
-        }
-
+        val kmFunction: KmFunction = companion.findFunctionByMethod(method)!!
         valueParameters = kmFunction.valueParameters.map { ValueParameter(it) }
         bucketGenerator = BucketGenerator(method.parameterTypes.asList(), kmFunction.valueParameters.hasVarargParam())
-        // endregion
     }
 
     private val defaultCaller: (args: ArgumentBucket) -> Any? by lazy {
         val valueParameterSize = method.parameterTypes.size
         val maskSize = calcMaskSize(valueParameterSize)
+        val companionObjectClass = companion.type
 
         @Suppress("UNCHECKED_CAST")
         val defaultTypes = method.parameterTypes.let { parameterTypes ->
+
             // companion object instance(1) + parameterSize + maskSize + marker(1)
             val temp = arrayOfNulls<Class<*>>(1 + valueParameterSize + maskSize + 1)
             temp[0] = companionObjectClass // companion object
@@ -67,7 +46,7 @@ internal class MethodValueCreator<T>(private val method: Method, declaringKmClas
         } as Array<Class<*>>
 
         val defaultMethod = companionObjectClass.getDeclaredMethodBy("${callableName}\$default", defaultTypes)
-        val companionObject = companionField.get(null)
+        val companionObject = companion.instance
 
         return@lazy {
             val defaultArgs = arrayOfNulls<Any?>(defaultTypes.size)

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCacheTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCacheTest.kt
@@ -18,13 +18,13 @@ class ReflectionCacheTest {
 
                 assertNotNull(deserialized)
                 // Deserialized instance also do not raise exceptions
-                deserialized.getKmClass(this::class.java)
+                deserialized.getJmClass(this::class.java)
             }
         }
 
         @Test
         fun notEmptyCache() {
-            val cache = ReflectionCache(100).apply { getKmClass(this::class.java) }
+            val cache = ReflectionCache(100).apply { getJmClass(this::class.java) }
             val serialized = jdkSerialize(cache)
 
             assertDoesNotThrow {
@@ -32,7 +32,7 @@ class ReflectionCacheTest {
 
                 assertNotNull(deserialized)
                 // Deserialized instance also do not raise exceptions
-                deserialized.getKmClass(this::class.java)
+                deserialized.getJmClass(this::class.java)
             }
         }
     }


### PR DESCRIPTION
- Reduced memory usage by retaining only the minimum information in `KmClass`.
- Improved reflection cache efficiency regarding `companion object`.
- Preparation for improved references to the content defined in the parent class interface.
- Preparation for improving `Creator`s cache efficiency.