### PR TITLE
Optimized to not use `isAssignableFrom`

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -85,7 +85,7 @@ internal class KotlinFallbackAnnotationIntrospector(
 
             valueParameter.createValueClassUnboxConverterOrNull(rawType) ?: run {
                 if (strictNullChecks) {
-                    valueParameter.createStrictNullChecksConverterOrNull(a.type, rawType)
+                    valueParameter.createStrictNullChecksConverterOrNull(a.type)
                 } else {
                     null
                 }
@@ -176,13 +176,13 @@ private fun ValueParameter.createValueClassUnboxConverterOrNull(rawType: Class<*
 // @see io.github.projectmapk.jackson.module.kogera._ported.test.StrictNullChecksTest#testListOfGenericWithNullValue
 private fun ValueParameter.isNullishTypeAt(index: Int) = arguments.getOrNull(index)?.isNullable ?: true
 
-private fun ValueParameter.createStrictNullChecksConverterOrNull(type: JavaType, rawType: Class<*>): Converter<*, *>? {
+private fun ValueParameter.createStrictNullChecksConverterOrNull(type: JavaType): Converter<*, *>? {
     return when {
-        Array::class.java.isAssignableFrom(rawType) && !this.isNullishTypeAt(0) ->
+        type.isArrayType && !this.isNullishTypeAt(0) ->
             CollectionValueStrictNullChecksConverter.ForArray(type, this.name)
-        Iterable::class.java.isAssignableFrom(rawType) && !this.isNullishTypeAt(0) ->
+        type.isCollectionLikeType && !this.isNullishTypeAt(0) ->
             CollectionValueStrictNullChecksConverter.ForIterable(type, this.name)
-        Map::class.java.isAssignableFrom(rawType) && !this.isNullishTypeAt(1) ->
+        type.isMapLikeType && !this.isNullishTypeAt(1) ->
             MapValueStrictNullChecksConverter(type, this.name)
         else -> null
     }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinSerializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinSerializers.kt
@@ -85,10 +85,10 @@ internal class KotlinSerializers : Serializers.Base() {
         val rawClass = type.rawClass
 
         return when {
-            UByte::class.java.isAssignableFrom(rawClass) -> UByteSerializer
-            UShort::class.java.isAssignableFrom(rawClass) -> UShortSerializer
-            UInt::class.java.isAssignableFrom(rawClass) -> UIntSerializer
-            ULong::class.java.isAssignableFrom(rawClass) -> ULongSerializer
+            UByte::class.java == rawClass -> UByteSerializer
+            UShort::class.java == rawClass -> UShortSerializer
+            UInt::class.java == rawClass -> UIntSerializer
+            ULong::class.java == rawClass -> ULongSerializer
             // The priority of Unboxing needs to be lowered so as not to break the serialization of Unsigned Integers.
             rawClass.isUnboxableValueClass() -> ValueClassStaticJsonValueSerializer.createOrNull(rawClass)
                 ?: ValueClassUnboxSerializer


### PR DESCRIPTION
Because they are used where there is no need and processing costs are expected to be relatively high.