### PR TITLE
Otimizes

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -14,13 +14,10 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 
-internal fun Class<*>.isUnboxableValueClass() = annotations.any { it is JvmInline }
+internal fun Class<*>.isUnboxableValueClass() = this.getAnnotation(JvmInline::class.java) != null
 
-internal fun Class<*>.toKmClass(): KmClass? = annotations
-    .filterIsInstance<Metadata>()
-    .firstOrNull()
-    ?.let { KotlinClassMetadata.read(it) as KotlinClassMetadata.Class }
-    ?.toKmClass()
+internal fun Class<*>.toKmClass(): KmClass? = this.getAnnotation(Metadata::class.java)
+    ?.let { (KotlinClassMetadata.read(it) as KotlinClassMetadata.Class).toKmClass() }
 
 private val primitiveClassToDesc by lazy {
     mapOf(
@@ -104,5 +101,6 @@ internal fun KmType.reconstructClassOrNull(): Class<*>? = (classifier as? KmClas
 
 internal fun KmType.isNullable(): Boolean = Flag.Type.IS_NULLABLE(this.flags)
 
-internal fun AnnotatedElement.hasCreatorAnnotation(): Boolean =
-    annotations.any { it is JsonCreator && it.mode != JsonCreator.Mode.DISABLED }
+internal fun AnnotatedElement.hasCreatorAnnotation(): Boolean = getAnnotation(JsonCreator::class.java)
+    ?.let { it.mode != JsonCreator.Mode.DISABLED }
+    ?: false

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -2,17 +2,25 @@ package io.github.projectmapk.jackson.module.kogera
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import kotlinx.metadata.Flag
+import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
+import kotlinx.metadata.jvm.KotlinClassMetadata
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 
 internal fun Class<*>.isUnboxableValueClass() = annotations.any { it is JvmInline }
+
+internal fun Class<*>.toKmClass(): KmClass? = annotations
+    .filterIsInstance<Metadata>()
+    .firstOrNull()
+    ?.let { KotlinClassMetadata.read(it) as KotlinClassMetadata.Class }
+    ?.toKmClass()
 
 private val primitiveClassToDesc by lazy {
     mapOf(

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -74,8 +74,4 @@ internal class JmClass(
             return kmClass.functions.find { it.signature == signature }
         }
     }
-
-    companion object {
-        fun createOrNull(clazz: Class<*>): JmClass? = clazz.toKmClass()?.let { JmClass(clazz, it) }
-    }
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -6,18 +6,11 @@ import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmProperty
-import kotlinx.metadata.jvm.KotlinClassMetadata
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
-
-private fun Class<*>.toKmClass(): KmClass? = annotations
-    .filterIsInstance<Metadata>()
-    .firstOrNull()
-    ?.let { KotlinClassMetadata.read(it) as KotlinClassMetadata.Class }
-    ?.toKmClass()
 
 // Jackson Metadata Class
 internal class JmClass(


### PR DESCRIPTION
- Fixed to not cache `JmClass` if `KmClass` cannot be retrieved
  - To cache more of the high-load conversion process
- Modified to use `getAnnotation` in the process of obtaining annotations from classes