### PR TITLE
Fixed so that inherited properties can also be parsed

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -26,8 +26,8 @@ internal class JmClass(
         }
 
         // Add properties of inherited classes and interfaces
-        // TODO: Ideally, more specific types should be preferred for each property,
-        //       but as a provisional implementation, the first one in is used.
+        // If an `interface` is implicitly implemented by an abstract class,
+        // it is necessary to obtain a more specific type, so always add it from the abstract class first.
         superJmClass?.allPropsMap?.forEach {
             this.putIfAbsent(it.key, it.value)
         }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -6,6 +6,7 @@ import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmProperty
+import kotlinx.metadata.jvm.fieldSignature
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Constructor
@@ -64,6 +65,10 @@ internal class JmClass(
             targetDesc == desc || targetDesc == valueDesc
         }
     }
+
+    // Field name always matches property name
+    fun findPropertyByField(field: Field): KmProperty? = allPropsMap[field.name]
+        ?.takeIf { it.fieldSignature == field.toSignature() }
 
     fun findPropertyByGetter(getter: Method): KmProperty? {
         val signature = getter.toSignature()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -22,7 +22,6 @@ import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.KmValueParameter
-import kotlinx.metadata.jvm.fieldSignature
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.setterSignature
 import kotlinx.metadata.jvm.signature
@@ -64,12 +63,10 @@ internal class KotlinPrimaryAnnotationIntrospector(
     // but deserialization is preferred because there is currently no way to distinguish between contexts.
     private fun AnnotatedField.hasRequiredMarker(jmClass: JmClass): Boolean? {
         val member = annotated
-        val fieldSignature = member.toSignature()
 
         // Direct access to `AnnotatedField` is only performed if there is no accessor (defined as JvmField),
         // so if an accessor is defined, it is ignored.
-        return jmClass.properties
-            .find { it.fieldSignature == fieldSignature }
+        return jmClass.findPropertyByField(member)
             // Since a property that does not currently have a getter cannot be defined,
             // only a check for the existence of a getter is performed.
             // https://youtrack.jetbrains.com/issue/KT-6519

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/ser/InheritanceTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/ser/InheritanceTest.kt
@@ -1,0 +1,29 @@
+package io.github.projectmapk.jackson.module.kogera._integration.ser
+
+import io.github.projectmapk.jackson.module.kogera.ReflectionCache
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+private class InheritanceTest {
+    abstract class A { val a: Int get() = 0 }
+
+    interface I { val i: Int get() = -1 }
+
+    interface J : I { val j: Int get() = -2 }
+
+    private class X : A(), J
+
+    val cache = ReflectionCache(5)
+
+    @Test
+    fun test() {
+        val c = cache.getJmClass(X::class.java)!!
+        val props = c.properties.associateBy { it.name }
+
+        assertEquals(3, props.size)
+        assertTrue(props.containsKey("a"))
+        assertTrue(props.containsKey("i"))
+        assertTrue(props.containsKey("j"))
+    }
+}


### PR DESCRIPTION
The `kmClass.properties` did not contain properties defined for inherited class properties, which could lead to parsing deficiencies with respect to such properties.