### PR TITLE
Fixed factory function retrieval from companion object

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -41,7 +41,6 @@ internal class JmClass(
     val flags: Flags = kmClass.flags
     val constructors: List<KmConstructor> = kmClass.constructors
     val properties: List<KmProperty> = allPropsMap.values.toList()
-    private val functions: List<KmFunction> = kmClass.functions
     val sealedSubclasses: List<ClassName> = kmClass.sealedSubclasses
     private val companionPropName: String? = kmClass.companionObject
     val companion: CompanionObject? by lazy { companionPropName?.let { CompanionObject(clazz, it) } }
@@ -73,11 +72,6 @@ internal class JmClass(
     fun findPropertyByGetter(getter: Method): KmProperty? {
         val signature = getter.toSignature()
         return properties.find { it.getterSignature == signature }
-    }
-
-    fun findFunctionByMethod(method: Method): KmFunction? {
-        val signature = method.toSignature()
-        return functions.find { it.signature == signature }
     }
 
     internal class CompanionObject(

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinPrimaryAnnotationIntrospector.kt
@@ -89,8 +89,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
     private fun AnnotatedParameter.hasRequiredMarker(jmClass: JmClass): Boolean? {
         val paramDef = when (val member = member) {
             is Constructor<*> -> jmClass.findKmConstructor(member)?.valueParameters
-
-            is Method -> jmClass.findFunctionByMethod(member)?.valueParameters
+            is Method -> jmClass.companion?.findFunctionByMethod(member)?.valueParameters
             else -> null
         }?.let { it[index] } ?: return null // Return null if function on Kotlin cannot be determined
 


### PR DESCRIPTION
It was mistakenly trying to retrieve from a declaringClass when it should have been retrieved from a `companion object`.
Therefore, the value of `required` (`nullability`) was incorrect.

At the same time, `functions` that did not need to be retained in `JmClass` were removed, thus reducing memory consumption.