### PR TITLE
ValueCreator modified to cache to KotlinValueInstantiator

### DIFF
--- a/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/value_instantiator/ReflectProperties.java
+++ b/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/value_instantiator/ReflectProperties.java
@@ -1,0 +1,71 @@
+package io.github.projectmapk.jackson.module.kogera.deser.value_instantiator;
+
+import kotlin.jvm.functions.Function0;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.ref.SoftReference;
+
+// ported from kotlin.reflect.jvm.internal.ReflectProperties 887dc to use LazySoft
+class ReflectProperties {
+    static abstract class Val<T> {
+        private static final Object NULL_VALUE = new Object() {
+        };
+
+        @SuppressWarnings({"UnusedParameters", "unused"})
+        final T getValue(Object instance, Object metadata) {
+            return invoke();
+        }
+
+        abstract T invoke();
+
+        protected Object escape(T value) {
+            return value == null ? NULL_VALUE : value;
+        }
+
+        @SuppressWarnings("unchecked")
+        protected T unescape(Object value) {
+            return value == NULL_VALUE ? null : (T) value;
+        }
+    }
+
+    // A delegate for a lazy property on a soft reference, whose initializer may be invoked multiple times
+    // including simultaneously from different threads
+    static class LazySoftVal<T> extends Val<T> implements Function0<T> {
+        private final Function0<T> initializer;
+        private volatile SoftReference<Object> value = null;
+
+        LazySoftVal(@Nullable T initialValue, @NotNull Function0<T> initializer) {
+            this.initializer = initializer;
+            if (initialValue != null) {
+                this.value = new SoftReference<Object>(escape(initialValue));
+            }
+        }
+
+        @Override
+        public T invoke() {
+            SoftReference<Object> cached = value;
+            if (cached != null) {
+                Object result = cached.get();
+                if (result != null) {
+                    return unescape(result);
+                }
+            }
+
+            T result = initializer.invoke();
+            value = new SoftReference<Object>(escape(result));
+
+            return result;
+        }
+    }
+
+    @NotNull
+    static <T> LazySoftVal<T> lazySoft(@Nullable T initialValue, @NotNull Function0<T> initializer) {
+        return new LazySoftVal<T>(initialValue, initializer);
+    }
+
+    @NotNull
+    static <T> LazySoftVal<T> lazySoft(@NotNull Function0<T> initializer) {
+        return lazySoft(null, initializer);
+    }
+}

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -2,14 +2,8 @@ package io.github.projectmapk.jackson.module.kogera
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.util.LRUMap
-import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.ConstructorValueCreator
-import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.MethodValueCreator
-import io.github.projectmapk.jackson.module.kogera.deser.value_instantiator.creator.ValueCreator
 import io.github.projectmapk.jackson.module.kogera.ser.ValueClassBoxConverter
 import java.io.Serializable
-import java.lang.reflect.Constructor
-import java.lang.reflect.Executable
-import java.lang.reflect.Method
 import java.util.Optional
 
 internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
@@ -21,7 +15,6 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
 
     // This cache is used for both serialization and deserialization, so reserve a larger size from the start.
     private val classCache = LRUMap<Class<*>, JmClass>(reflectionCacheSize, reflectionCacheSize)
-    private val creatorCache: LRUMap<Executable, ValueCreator<*>>
 
     // Initial size is 0 because the value class is not always used
     private val valueClassReturnTypeCache: LRUMap<AnnotatedMethod, Optional<Class<*>>> =
@@ -31,21 +24,6 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     //       since the cache is used only twice locally at initialization per property.
     private val valueClassBoxConverterCache: LRUMap<Class<*>, ValueClassBoxConverter<*, *>> =
         LRUMap(0, reflectionCacheSize)
-
-    init {
-        // The current default value of reflectionCacheSize is 512.
-        // If less than 512 is specified, initialEntries shall be half of the reflectionCacheSize,
-        // since it is assumed that the situation does not require a large amount of space from the beginning.
-        // Conversely, if reflectionCacheSize is increased,
-        // the amount of cache is considered to be a performance bottleneck,
-        // and therefore reflectionCacheSize is used as is for initialEntries.
-        val initialEntries = if (reflectionCacheSize <= KotlinModule.Builder.reflectionCacheSizeDefault) {
-            reflectionCacheSize / 2
-        } else {
-            reflectionCacheSize
-        }
-        creatorCache = LRUMap(initialEntries, reflectionCacheSize)
-    }
 
     fun getJmClass(clazz: Class<*>): JmClass? {
         return classCache[clazz] ?: run {
@@ -65,35 +43,6 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             (classCache.putIfAbsent(clazz, value) ?: value)
         }
     }
-
-    /**
-     * return null if declaringClass is not kotlin class
-     */
-    fun valueCreatorFromJava(creator: Executable): ValueCreator<*>? = when (creator) {
-        is Constructor<*> -> {
-            creatorCache.get(creator)
-                ?: run {
-                    getJmClass(creator.declaringClass)?.let {
-                        val value = ConstructorValueCreator(creator, it)
-                        creatorCache.putIfAbsent(creator, value) ?: value
-                    }
-                }
-        }
-
-        is Method -> {
-            creatorCache.get(creator)
-                ?: run {
-                    getJmClass(creator.declaringClass)?.let {
-                        val value = MethodValueCreator<Any?>(creator, it)
-                        creatorCache.putIfAbsent(creator, value) ?: value
-                    }
-                }
-        }
-
-        else -> throw IllegalStateException(
-            "Expected a constructor or method to create a Kotlin object, instead found ${creator.javaClass.name}"
-        )
-    } // we cannot reflect this method so do the default Java-ish behavior
 
     private fun AnnotatedMethod.getValueClassReturnType(): Class<*>? {
         val getter = this.member.apply {

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -16,7 +16,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     companion object {
         // Increment is required when properties that use LRUMap are changed.
         @Suppress("ConstPropertyName")
-        private const val serialVersionUID = 1L
+        private const val serialVersionUID = 2L
     }
 
     // This cache is used for both serialization and deserialization, so reserve a larger size from the start.


### PR DESCRIPTION
The following benefits can be obtained

- Throughput is increased because searches are no longer performed in the reflection cache
- Tuning is simplified because memory is released based on memory usage