### PR TITLE
Remove `getter-like`/`setter-like` ignore processing.

### DIFF
--- a/docs/KogeraSpecificImplementations.md
+++ b/docs/KogeraSpecificImplementations.md
@@ -2,15 +2,6 @@ In `jackson-module-kogera`, there are several intentional design changes that ar
 This page summarizes them.
 
 # Common
-## Set `Kotlin Property` as positive and ignore functions.
-In `jackson-module-kotlin`, functions with getterLike or setterLike names are handled in the same way as `Kotlin Property`.  
-On the other hand, this implementation causes discrepancies between the `Kotlin` description and the processing results by `Jackson`.
-
-Therefore, `kogera` processes only `Kotlin Property` and excludes other functions from processing.  
-In addition, `kogera` uses the content defined in `Kotlin` as its name.
-
-These changes make it impossible to manipulate the results using `JvmName`.
-
 ## Change of `hasRequiredMarker` specification
 The `KotlinAnnotationIntrospector::hasRequiredMarker` function in `jackson-module-kotlin` has several problems.
 In `kogera`, the specification has been revised as follows.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -1,6 +1,5 @@
 package io.github.projectmapk.jackson.module.kogera.annotation_introspector
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.cfg.MapperConfig
@@ -20,11 +19,9 @@ import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
 import io.github.projectmapk.jackson.module.kogera.ser.SequenceToIteratorConverter
-import io.github.projectmapk.jackson.module.kogera.toSignature
 import kotlinx.metadata.KmTypeProjection
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.fieldSignature
-import kotlinx.metadata.jvm.setterSignature
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -57,23 +54,6 @@ internal class KotlinFallbackAnnotationIntrospector(
         }
         is AnnotatedParameter -> findKotlinParameter(member)?.name
         else -> null
-    }
-
-    // If it is not a property on Kotlin, it is not used to ser/deserialization
-    override fun findPropertyAccess(ann: Annotated): JsonProperty.Access? = (ann as? AnnotatedMethod)?.let { _ ->
-        cache.getJmClass(ann.declaringClass)?.let { jmClass ->
-            val method = ann.annotated
-
-            // By returning an illegal JsonProperty.Access, it is effectively ignore.
-            when (method.parameters.size) {
-                0 -> JsonProperty.Access.WRITE_ONLY.takeIf { jmClass.findPropertyByGetter(method) == null }
-                1 -> {
-                    val signature = method.toSignature()
-                    JsonProperty.Access.READ_ONLY.takeIf { jmClass.properties.none { it.setterSignature == signature } }
-                }
-                else -> null
-            }
-        }
     }
 
     // returns Converter when the argument on Java is an unboxed value class

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/ser/PropertySerializeTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/ser/PropertySerializeTest.kt
@@ -15,10 +15,7 @@ class PropertySerializeTest {
         @Suppress("PropertyName") val `baz-baz`: String,
         // https://github.com/FasterXML/jackson-module-kotlin/issues/503
         val nQux: Int
-    ) {
-        // Ignored because it is not a Kotlin property
-        fun getZzz(): Int = -1
-    }
+    )
 
     @Test
     fun test() {

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_ported/test/github/Github464.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_ported/test/github/Github464.kt
@@ -38,7 +38,8 @@ class Github464 {
     interface IGetter<T> {
         val quux: T
 
-        val xyzzy: T get() = quux
+        // see #129
+        // val xyzzy: T get() = quux
     }
 
     class Poko(
@@ -106,7 +107,6 @@ class Github464 {
                         "1" : null,
                         "null-key" : null
                       },
-                      "xyzzy" : 0,
                       "plugh" : 0
                     }
                 """.trimIndent(),
@@ -142,7 +142,6 @@ class Github464 {
                         "1" : "null-value",
                         "null-key" : "null-value"
                       },
-                      "xyzzy" : 0,
                       "plugh" : 0
                     }
                 """.trimIndent(),


### PR DESCRIPTION
This ignore process does not enhance usability but has overhead for the first time execution.