### PR TITLE
Use ValueClassBoxConverter for deserialization box processing.

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -3,8 +3,12 @@ package io.github.projectmapk.jackson.module.kogera
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
 import com.fasterxml.jackson.databind.util.StdConverter
 
-// S is nullable because value corresponds to a nullable value class
-// @see KotlinFallbackAnnotationIntrospector.findNullSerializer
+/**
+ * A converter that only performs box processing for the value class.
+ * Note that constructor-impl is not called.
+ * @param S is nullable because value corresponds to a nullable value class.
+ *   see [io.github.projectmapk.jackson.module.kogera.annotation_introspector.KotlinFallbackAnnotationIntrospector.findNullSerializer]
+ */
 internal class ValueClassBoxConverter<S : Any?, D : Any>(
     unboxedClass: Class<S>,
     valueClass: Class<D>

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -1,0 +1,20 @@
+package io.github.projectmapk.jackson.module.kogera
+
+import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
+import com.fasterxml.jackson.databind.util.StdConverter
+
+// S is nullable because value corresponds to a nullable value class
+// @see KotlinFallbackAnnotationIntrospector.findNullSerializer
+internal class ValueClassBoxConverter<S : Any?, D : Any>(
+    unboxedClass: Class<S>,
+    valueClass: Class<D>
+) : StdConverter<S, D>() {
+    private val boxMethod = valueClass.getDeclaredMethod("box-impl", unboxedClass).apply {
+        if (!this.isAccessible) this.isAccessible = true
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun convert(value: S): D = boxMethod.invoke(null, value) as D
+
+    val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
+}

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.util.StdConverter
  */
 internal class ValueClassBoxConverter<S : Any?, D : Any>(
     unboxedClass: Class<S>,
-    valueClass: Class<D>
+    val valueClass: Class<D>
 ) : StdConverter<S, D>() {
     private val boxMethod = valueClass.getDeclaredMethod("box-impl", unboxedClass).apply {
         if (!this.isAccessible) this.isAccessible = true

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -2,7 +2,6 @@ package io.github.projectmapk.jackson.module.kogera
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod
 import com.fasterxml.jackson.databind.util.LRUMap
-import io.github.projectmapk.jackson.module.kogera.ser.ValueClassBoxConverter
 import java.io.Serializable
 import java.util.Optional
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import io.github.projectmapk.jackson.module.kogera.JmClass
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
+import io.github.projectmapk.jackson.module.kogera.ValueClassBoxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.JavaToKotlinDurationConverter
 import io.github.projectmapk.jackson.module.kogera.hasCreatorAnnotation
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
@@ -75,26 +76,23 @@ internal object ULongDeserializer : StdDeserializer<ULong>(ULong::class.java) {
         ULongChecker.readWithRangeCheck(p, p.bigIntegerValue)
 }
 
-internal class ValueClassBoxDeserializer<T : Any>(
+internal class ValueClassBoxDeserializer<S, D : Any>(
     private val creator: Method,
-    clazz: Class<T>
-) : StdDeserializer<T>(clazz) {
+    private val converter: ValueClassBoxConverter<S, D>
+) : StdDeserializer<D>(converter.valueClass) {
     private val inputType: Class<*> = creator.parameterTypes[0]
-    private val boxMethod: Method = clazz
-        .getDeclaredMethod("box-impl", clazz.getDeclaredMethod("unbox-impl").returnType)
-        .apply { if (!this.isAccessible) this.isAccessible = true }
 
     init {
         creator.apply { if (!this.isAccessible) this.isAccessible = true }
     }
 
-    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): T {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): D {
         val input = p.readValueAs(inputType)
 
         // To instantiate the value class in the same way as other classes,
         // it is necessary to call creator(e.g. constructor-impl) -> box-impl in that order.
         @Suppress("UNCHECKED_CAST")
-        return boxMethod.invoke(null, creator.invoke(null, input)) as T
+        return converter.convert(creator.invoke(null, input) as S)
     }
 }
 
@@ -149,8 +147,11 @@ internal class KotlinDeserializers(
             rawClass == ULong::class.java -> ULongDeserializer
             rawClass == KotlinDuration::class.java ->
                 JavaToKotlinDurationConverter.takeIf { useJavaDurationConversion }?.delegatingDeserializer
-            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)
-                ?.let { ValueClassBoxDeserializer(it, rawClass) }
+            rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)?.let {
+                val unboxedClass = rawClass.getMethod("unbox-impl").returnType
+                val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass)
+                ValueClassBoxDeserializer(it, converter)
+            }
             else -> null
         }
     }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/Converters.kt
@@ -1,11 +1,11 @@
 package io.github.projectmapk.jackson.module.kogera.ser
 
 import com.fasterxml.jackson.databind.JavaType
-import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
 import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.StdConverter
 import io.github.projectmapk.jackson.module.kogera.JavaDuration
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
+import io.github.projectmapk.jackson.module.kogera.ValueClassBoxConverter
 import kotlin.time.toJavaDuration
 
 internal class SequenceToIteratorConverter(private val input: JavaType) : StdConverter<Sequence<*>, Iterator<*>>() {
@@ -17,22 +17,6 @@ internal class SequenceToIteratorConverter(private val input: JavaType) : StdCon
     override fun getOutputType(typeFactory: TypeFactory): JavaType = input.containedType(0)
         ?.let { typeFactory.constructCollectionLikeType(Iterator::class.java, it) }
         ?: typeFactory.constructType(Iterator::class.java)
-}
-
-// S is nullable because value corresponds to a nullable value class
-// @see KotlinFallbackAnnotationIntrospector.findNullSerializer
-internal class ValueClassBoxConverter<S : Any?, D : Any>(
-    unboxedClass: Class<S>,
-    valueClass: Class<D>
-) : StdConverter<S, D>() {
-    private val boxMethod = valueClass.getDeclaredMethod("box-impl", unboxedClass).apply {
-        if (!this.isAccessible) this.isAccessible = true
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun convert(value: S): D = boxMethod.invoke(null, value) as D
-
-    val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
 }
 
 internal object KotlinDurationValueToJavaDurationConverter : StdConverter<Long, JavaDuration>() {


### PR DESCRIPTION
If the same `value class` is used for both serialization and deserialization, the initialization performance is improved because the `box-impl` is obtained once.