### PR TITLE
Fix to reuse ValueClassUnboxConverter

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -36,4 +36,6 @@ internal class ValueClassUnboxConverter<T : Any>(val valueClass: Class<T>) : Std
     override fun getInputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(valueClass)
     override fun getOutputType(typeFactory: TypeFactory): JavaType =
         typeFactory.constructType(unboxMethod.genericReturnType)
+
+    val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -1,6 +1,8 @@
 package io.github.projectmapk.jackson.module.kogera
 
+import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ser.std.StdDelegatingSerializer
+import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.StdConverter
 
 /**
@@ -21,4 +23,14 @@ internal class ValueClassBoxConverter<S : Any?, D : Any>(
     override fun convert(value: S): D = boxMethod.invoke(null, value) as D
 
     val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
+}
+
+internal class ValueClassUnboxConverter<T : Any>(private val valueClass: Class<T>) : StdConverter<T, Any?>() {
+    private val unboxMethod = valueClass.getDeclaredMethod("unbox-impl").apply {
+        if (!this.isAccessible) this.isAccessible = true
+    }
+
+    override fun convert(value: T): Any? = unboxMethod.invoke(value)
+
+    override fun getInputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(valueClass)
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -29,6 +29,7 @@ internal class ValueClassUnboxConverter<T : Any>(private val valueClass: Class<T
     private val unboxMethod = valueClass.getDeclaredMethod("unbox-impl").apply {
         if (!this.isAccessible) this.isAccessible = true
     }
+    val unboxedClass: Class<*> = unboxMethod.returnType
 
     override fun convert(value: T): Any? = unboxMethod.invoke(value)
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -25,7 +25,7 @@ internal class ValueClassBoxConverter<S : Any?, D : Any>(
     val delegatingSerializer: StdDelegatingSerializer by lazy { StdDelegatingSerializer(this) }
 }
 
-internal class ValueClassUnboxConverter<T : Any>(private val valueClass: Class<T>) : StdConverter<T, Any?>() {
+internal class ValueClassUnboxConverter<T : Any>(val valueClass: Class<T>) : StdConverter<T, Any?>() {
     private val unboxMethod = valueClass.getDeclaredMethod("unbox-impl").apply {
         if (!this.isAccessible) this.isAccessible = true
     }
@@ -34,4 +34,6 @@ internal class ValueClassUnboxConverter<T : Any>(private val valueClass: Class<T
     override fun convert(value: T): Any? = unboxMethod.invoke(value)
 
     override fun getInputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(valueClass)
+    override fun getOutputType(typeFactory: TypeFactory): JavaType =
+        typeFactory.constructType(unboxMethod.genericReturnType)
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
@@ -102,7 +102,7 @@ public class KotlinModule private constructor(
 
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers)
-        context.addSerializers(KotlinSerializers())
+        context.addSerializers(KotlinSerializers(cache))
         context.addKeySerializers(KotlinKeySerializers(cache))
 
         // ranges

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
@@ -103,7 +103,7 @@ public class KotlinModule private constructor(
         context.addDeserializers(KotlinDeserializers(cache, useJavaDurationConversion))
         context.addKeyDeserializers(KotlinKeyDeserializers)
         context.addSerializers(KotlinSerializers())
-        context.addKeySerializers(KotlinKeySerializers())
+        context.addKeySerializers(KotlinKeySerializers(cache))
 
         // ranges
         context.setMixInAnnotations(ClosedRange::class.java, ClosedRangeMixin::class.java)

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -9,7 +9,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     companion object {
         // Increment is required when properties that use LRUMap are changed.
         @Suppress("ConstPropertyName")
-        private const val serialVersionUID = 2L
+        private const val serialVersionUID = 3L
     }
 
     // This cache is used for both serialization and deserialization, so reserve a larger size from the start.
@@ -22,6 +22,8 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     // TODO: Consider whether the cache size should be reduced more,
     //       since the cache is used only twice locally at initialization per property.
     private val valueClassBoxConverterCache: LRUMap<Class<*>, ValueClassBoxConverter<*, *>> =
+        LRUMap(0, reflectionCacheSize)
+    private val valueClassUnboxConverterCache: LRUMap<Class<*>, ValueClassUnboxConverter<*>> =
         LRUMap(0, reflectionCacheSize)
 
     fun getJmClass(clazz: Class<*>): JmClass? {
@@ -74,5 +76,12 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             val value = ValueClassBoxConverter(unboxedClass, valueClass)
 
             (valueClassBoxConverterCache.putIfAbsent(valueClass, value) ?: value)
+        }
+
+    fun getValueClassUnboxConverter(valueClass: Class<*>): ValueClassUnboxConverter<*> =
+        valueClassUnboxConverterCache.get(valueClass) ?: run {
+            val value = ValueClassUnboxConverter(valueClass)
+
+            (valueClassUnboxConverterCache.putIfAbsent(valueClass, value) ?: value)
         }
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -13,9 +13,9 @@ import com.fasterxml.jackson.databind.type.TypeFactory
 import com.fasterxml.jackson.databind.util.Converter
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
+import io.github.projectmapk.jackson.module.kogera.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.CollectionValueStrictNullChecksConverter
 import io.github.projectmapk.jackson.module.kogera.deser.MapValueStrictNullChecksConverter
-import io.github.projectmapk.jackson.module.kogera.deser.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/Converters.kt
@@ -10,16 +10,6 @@ import io.github.projectmapk.jackson.module.kogera.JavaDuration
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import kotlin.time.toKotlinDuration
 
-internal class ValueClassUnboxConverter<T : Any>(private val valueClass: Class<T>) : StdConverter<T, Any?>() {
-    private val unboxMethod = valueClass.getDeclaredMethod("unbox-impl").apply {
-        if (!this.isAccessible) this.isAccessible = true
-    }
-
-    override fun convert(value: T): Any? = unboxMethod.invoke(value)
-
-    override fun getInputType(typeFactory: TypeFactory): JavaType = typeFactory.constructType(valueClass)
-}
-
 internal sealed class CollectionValueStrictNullChecksConverter<T : Any> : Converter<T, T> {
     protected abstract val type: JavaType
     protected abstract val paramName: String

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -148,7 +148,7 @@ internal class KotlinDeserializers(
             rawClass == KotlinDuration::class.java ->
                 JavaToKotlinDurationConverter.takeIf { useJavaDurationConversion }?.delegatingDeserializer
             rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)?.let {
-                val unboxedClass = rawClass.getMethod("unbox-impl").returnType
+                val unboxedClass = cache.getValueClassUnboxConverter(rawClass).unboxedClass
                 val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass)
                 ValueClassBoxDeserializer(it, converter)
             }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinKeySerializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinKeySerializers.kt
@@ -9,17 +9,20 @@ import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import io.github.projectmapk.jackson.module.kogera.ReflectionCache
+import io.github.projectmapk.jackson.module.kogera.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
-internal object ValueClassUnboxKeySerializer : StdSerializer<Any>(Any::class.java) {
-    override fun serialize(value: Any, gen: JsonGenerator, provider: SerializerProvider) {
-        val method = value::class.java.getMethod("unbox-impl")
-        val unboxed = method.invoke(value)
+internal class ValueClassUnboxKeySerializer<T : Any>(
+    private val converter: ValueClassUnboxConverter<T>
+) : StdSerializer<T>(converter.valueClass) {
+    override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
+        val unboxed = converter.convert(value)
 
         if (unboxed == null) {
-            val javaType = provider.typeFactory.constructType(method.genericReturnType)
+            val javaType = converter.getOutputType(provider.typeFactory)
             provider.findNullKeySerializer(javaType, null).serialize(null, gen, provider)
             return
         }
@@ -33,15 +36,14 @@ private fun Class<*>.getStaticJsonKeyGetter(): Method? = this.declaredMethods.fi
     Modifier.isStatic(method.modifiers) && method.annotations.any { it is JsonKey && it.value }
 }
 
-internal class ValueClassStaticJsonKeySerializer<T>(
-    t: Class<T>,
+internal class ValueClassStaticJsonKeySerializer<T : Any>(
+    private val converter: ValueClassUnboxConverter<T>,
     private val staticJsonKeyGetter: Method
-) : StdSerializer<T>(t) {
+) : StdSerializer<T>(converter.valueClass) {
     private val keyType: Class<*> = staticJsonKeyGetter.returnType
-    private val unboxMethod: Method = t.getMethod("unbox-impl")
 
     override fun serialize(value: T, gen: JsonGenerator, provider: SerializerProvider) {
-        val unboxed = unboxMethod.invoke(value)
+        val unboxed = converter.convert(value)
         // As shown in the processing of the factory function, jsonValueGetter is always a static method.
         val jsonKey: Any? = staticJsonKeyGetter.invoke(null, unboxed)
 
@@ -57,19 +59,26 @@ internal class ValueClassStaticJsonKeySerializer<T>(
         // If create a function with a JsonValue in the value class,
         // it will be compiled as a static method (= cannot be processed properly by Jackson),
         // so use a ValueClassSerializer.StaticJsonValue to handle this.
-        fun createOrNull(t: Class<*>): StdSerializer<*>? =
-            t.getStaticJsonKeyGetter()?.let { ValueClassStaticJsonKeySerializer(t, it) }
+        fun <T : Any> createOrNull(converter: ValueClassUnboxConverter<T>): StdSerializer<T>? =
+            converter.valueClass.getStaticJsonKeyGetter()?.let { ValueClassStaticJsonKeySerializer(converter, it) }
     }
 }
 
-internal class KotlinKeySerializers : Serializers.Base() {
+internal class KotlinKeySerializers(private val cache: ReflectionCache) : Serializers.Base() {
     override fun findSerializer(
         config: SerializationConfig,
         type: JavaType,
         beanDesc: BeanDescription
-    ): JsonSerializer<*>? = when {
-        type.rawClass.isUnboxableValueClass() -> ValueClassStaticJsonKeySerializer.createOrNull(type.rawClass)
-            ?: ValueClassUnboxKeySerializer
-        else -> null
+    ): JsonSerializer<*>? {
+        val rawClass = type.rawClass
+
+        return when {
+            rawClass.isUnboxableValueClass() -> {
+                val unboxConverter = cache.getValueClassUnboxConverter(rawClass)
+                ValueClassStaticJsonKeySerializer.createOrNull(unboxConverter)
+                    ?: ValueClassUnboxKeySerializer(unboxConverter)
+            }
+            else -> null
+        }
     }
 }


### PR DESCRIPTION
Initialization performance is improved because the process of getting `unbox-impl` is cached.
Also, throughput will be improved because the method obtained once will be used instead of acquiring `unbox-impl` every time serialization has been performed so far.