### PR TITLE
Fixed ClosedRange conversions to be handled by AbstractTypeResolver

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ClosedRangeResolver.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ClosedRangeResolver.kt
@@ -1,0 +1,51 @@
+package io.github.projectmapk.jackson.module.kogera
+
+import com.fasterxml.jackson.databind.AbstractTypeResolver
+import com.fasterxml.jackson.databind.DeserializationConfig
+import com.fasterxml.jackson.databind.JavaType
+
+/*
+ * ClosedRange, which is not a concrete type like IntRange, does not have a type to deserialize to,
+ * so deserialization by ClosedRangeMixin does not work.
+ * Therefore, this process provides a concrete type.
+ *
+ * The target of processing is ClosedRange and interfaces or abstract classes that inherit from it.
+ * As of Kotlin 1.5.32, ClosedRange and ClosedFloatingPointRange are processed.
+ */
+internal object ClosedRangeResolver : AbstractTypeResolver() {
+    // At present, it depends on the private class, but if it is made public, it must be switched to a direct reference.
+    // see https://youtrack.jetbrains.com/issue/KT-55376
+    val closedDoubleRangeRef: Class<*> by lazy {
+        Class.forName("kotlin.ranges.ClosedDoubleRange")
+    }
+
+    val closedFloatRangeRef: Class<*>? by lazy {
+        Class.forName("kotlin.ranges.ClosedFloatRange")
+    }
+
+    fun findClosedFloatingPointRangeRef(contentType: Class<*>): Class<*>? = when (contentType) {
+        Double::class.javaPrimitiveType, Double::class.javaObjectType -> closedDoubleRangeRef
+        Float::class.javaPrimitiveType, Float::class.javaObjectType -> closedFloatRangeRef
+        else -> null
+    }
+
+    val comparableRangeClass: Class<*> by lazy {
+        Class.forName("kotlin.ranges.ComparableRange")
+    }
+
+    override fun findTypeMapping(config: DeserializationConfig, type: JavaType): JavaType? {
+        val rawClass = type.rawClass
+
+        return if (rawClass == ClosedRange::class.java || rawClass == ClosedFloatingPointRange::class.java) {
+            type.bindings.typeParameters.firstOrNull()
+                ?.let { typeParam ->
+                    findClosedFloatingPointRangeRef(typeParam.rawClass)?.let {
+                        config.typeFactory.constructType(it)
+                    }
+                }
+                ?: config.typeFactory.constructParametricType(comparableRangeClass, type.bindings)
+        } else {
+            super.findTypeMapping(config, type)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
@@ -107,6 +107,7 @@ public class KotlinModule private constructor(
 
         // ranges
         context.setMixInAnnotations(ClosedRange::class.java, ClosedRangeMixin::class.java)
+        context.addAbstractTypeResolver(ClosedRangeResolver)
     }
 
     public class Builder {

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/ClosedRangesTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/ClosedRangesTest.kt
@@ -1,6 +1,6 @@
 package io.github.projectmapk.jackson.module.kogera._integration
 
-import io.github.projectmapk.jackson.module.kogera.annotation_introspector.ClosedRangeHelpers
+import io.github.projectmapk.jackson.module.kogera.ClosedRangeResolver
 import io.github.projectmapk.jackson.module.kogera.jacksonObjectMapper
 import io.github.projectmapk.jackson.module.kogera.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -54,29 +54,29 @@ class ClosedRangesTest {
 
     @Test
     fun loadClasses() {
-        assertNotNull(ClosedRangeHelpers.closedDoubleRangeRef)
-        assertNotNull(ClosedRangeHelpers.closedFloatRangeRef)
-        assertNotNull(ClosedRangeHelpers.comparableRangeClass)
+        assertNotNull(ClosedRangeResolver.closedDoubleRangeRef)
+        assertNotNull(ClosedRangeResolver.closedFloatRangeRef)
+        assertNotNull(ClosedRangeResolver.comparableRangeClass)
     }
 
     @Test
     fun findClosedFloatingPointRangeRefTest() {
         assertEquals(
-            ClosedRangeHelpers.closedDoubleRangeRef,
-            ClosedRangeHelpers.findClosedFloatingPointRangeRef(Double::class.javaPrimitiveType!!)
+            ClosedRangeResolver.closedDoubleRangeRef,
+            ClosedRangeResolver.findClosedFloatingPointRangeRef(Double::class.javaPrimitiveType!!)
         )
         assertEquals(
-            ClosedRangeHelpers.closedDoubleRangeRef,
-            ClosedRangeHelpers.findClosedFloatingPointRangeRef(Double::class.javaObjectType)
+            ClosedRangeResolver.closedDoubleRangeRef,
+            ClosedRangeResolver.findClosedFloatingPointRangeRef(Double::class.javaObjectType)
         )
 
         assertEquals(
-            ClosedRangeHelpers.closedFloatRangeRef,
-            ClosedRangeHelpers.findClosedFloatingPointRangeRef(Float::class.javaPrimitiveType!!)
+            ClosedRangeResolver.closedFloatRangeRef,
+            ClosedRangeResolver.findClosedFloatingPointRangeRef(Float::class.javaPrimitiveType!!)
         )
         assertEquals(
-            ClosedRangeHelpers.closedFloatRangeRef,
-            ClosedRangeHelpers.findClosedFloatingPointRangeRef(Float::class.javaObjectType)
+            ClosedRangeResolver.closedFloatRangeRef,
+            ClosedRangeResolver.findClosedFloatingPointRangeRef(Float::class.javaObjectType)
         )
     }
 }


### PR DESCRIPTION
Because it is a function for type conversion, it is easier to understand the role than using refineDeserializationType, which can handle a variety of content.