### PR TITLE
Cache efficiency for boxed return types

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -57,18 +57,17 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
 
     // Return boxed type on Kotlin for unboxed getters
     fun findBoxedReturnType(getter: AnnotatedMethod): Class<*>? {
-        val method = getter.member.apply {
-            // If the return value of the getter is a value class,
-            // it will be serialized properly without doing anything.
-            // TODO: Verify the case where a value class encompasses another value class.
-            if (this.returnType.isUnboxableValueClass()) return null
-        }
-
+        val method = getter.member
         val optional = valueClassReturnTypeCache.get(method)
 
         return if (optional != null) {
             optional
         } else {
+            // If the return value of the getter is a value class,
+            // it will be serialized properly without doing anything.
+            // TODO: Verify the case where a value class encompasses another value class.
+            if (method.returnType.isUnboxableValueClass()) return null
+
             val value = Optional.ofNullable(method.getValueClassReturnType())
             (valueClassReturnTypeCache.putIfAbsent(method, value) ?: value)
         }.orElse(null)

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -17,7 +17,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
     private val classCache = LRUMap<Class<*>, JmClass>(reflectionCacheSize, reflectionCacheSize)
 
     // Initial size is 0 because the value class is not always used
-    private val valueClassReturnTypeCache: LRUMap<AnnotatedMethod, Optional<Class<*>>> =
+    private val valueClassReturnTypeCache: LRUMap<Method, Optional<Class<*>>> =
         LRUMap(0, reflectionCacheSize)
 
     // TODO: Consider whether the cache size should be reduced more,
@@ -70,7 +70,7 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
             optional
         } else {
             val value = Optional.ofNullable(method.getValueClassReturnType())
-            (valueClassReturnTypeCache.putIfAbsent(getter, value) ?: value)
+            (valueClassReturnTypeCache.putIfAbsent(method, value) ?: value)
         }.orElse(null)
     }
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -55,7 +55,8 @@ internal class ReflectionCache(reflectionCacheSize: Int) : Serializable {
         return kotlinProperty?.returnType?.reconstructClassOrNull()?.takeIf { it.isUnboxableValueClass() }
     }
 
-    fun findValueClassReturnType(getter: AnnotatedMethod): Class<*>? {
+    // Return boxed type on Kotlin for unboxed getters
+    fun findBoxedReturnType(getter: AnnotatedMethod): Class<*>? {
         val method = getter.member.apply {
             // If the return value of the getter is a value class,
             // it will be serialized properly without doing anything.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotation_introspector/KotlinFallbackAnnotationIntrospector.kt
@@ -76,7 +76,7 @@ internal class KotlinFallbackAnnotationIntrospector(
 
     override fun findSerializationConverter(a: Annotated): Converter<*, *>? = when (a) {
         // Find a converter to handle the case where the getter returns an unboxed value from the value class.
-        is AnnotatedMethod -> cache.findValueClassReturnType(a)?.let {
+        is AnnotatedMethod -> cache.findBoxedReturnType(a)?.let {
             if (useJavaDurationConversion && it == KotlinDuration::class.java) {
                 if (a.rawReturnType == KotlinDuration::class.java) {
                     KotlinToJavaDurationConverter
@@ -110,7 +110,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     // Perform proper serialization even if the value wrapped by the value class is null.
     // If value is a non-null object type, it must not be reboxing.
     override fun findNullSerializer(am: Annotated): JsonSerializer<*>? = (am as? AnnotatedMethod)?.let { _ ->
-        cache.findValueClassReturnType(am)?.let {
+        cache.findBoxedReturnType(am)?.let {
             if (it.requireRebox()) cache.getValueClassBoxConverter(am.rawReturnType, it).delegatingSerializer else null
         }
     }


### PR DESCRIPTION
Modified to not register records for `getter` that returns `value class` directly, since there is little need to cache it.
In addition, `Key` in `Map` was changed to `Method` due to the following issue.
https://github.com/FasterXML/jackson-databind/issues/4150