### PR TITLE
Changed `StrictNullChecks` to use `contentNulls` of `JsonSetter`

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinFeature.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinFeature.kt
@@ -53,7 +53,9 @@ public enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      *
      * With this disabled, the default, collections which are typed to disallow null members (e.g. `List<String>`)
      * may contain null values after deserialization.
-     * Enabling it protects against this but has performance impact.
+     * Enabling it protects against this, but it impairs performance a bit.
+     *
+     * Also, if contentNulls are custom from findSetterInfo in AnnotationIntrospector, there may be a conflict.
      */
     StrictNullChecks(enabledByDefault = false),
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/Converters.kt
@@ -1,72 +1,10 @@
 package io.github.projectmapk.jackson.module.kogera.deser
 
-import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer
-import com.fasterxml.jackson.databind.exc.MismatchedInputException
-import com.fasterxml.jackson.databind.type.TypeFactory
-import com.fasterxml.jackson.databind.util.Converter
 import com.fasterxml.jackson.databind.util.StdConverter
 import io.github.projectmapk.jackson.module.kogera.JavaDuration
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import kotlin.time.toKotlinDuration
-
-internal sealed class CollectionValueStrictNullChecksConverter<T : Any> : Converter<T, T> {
-    protected abstract val type: JavaType
-    protected abstract val paramName: String
-
-    protected abstract fun getValues(value: T): Iterator<*>
-
-    override fun convert(value: T): T {
-        getValues(value).forEach {
-            if (it == null) {
-                throw MismatchedInputException.from(
-                    null,
-                    null as JavaType?,
-                    "A null value was entered for the parameter $paramName."
-                )
-            }
-        }
-
-        return value
-    }
-
-    override fun getInputType(typeFactory: TypeFactory): JavaType = type
-    override fun getOutputType(typeFactory: TypeFactory): JavaType = type
-
-    class ForIterable(
-        override val type: JavaType,
-        override val paramName: String
-    ) : CollectionValueStrictNullChecksConverter<Iterable<*>>() {
-        override fun getValues(value: Iterable<*>): Iterator<*> = value.iterator()
-    }
-
-    class ForArray constructor(
-        override val type: JavaType,
-        override val paramName: String
-    ) : CollectionValueStrictNullChecksConverter<Array<*>>() {
-        override fun getValues(value: Array<*>): Iterator<*> = value.iterator()
-    }
-}
-
-internal class MapValueStrictNullChecksConverter(
-    private val type: JavaType,
-    private val paramName: String
-) : Converter<Map<*, *>, Map<*, *>> {
-    override fun convert(value: Map<*, *>): Map<*, *> = value.apply {
-        entries.forEach { (k, v) ->
-            if (v == null) {
-                throw MismatchedInputException.from(
-                    null,
-                    null as JavaType?,
-                    "A null value was entered for key $k of the parameter $paramName."
-                )
-            }
-        }
-    }
-
-    override fun getInputType(typeFactory: TypeFactory): JavaType = type
-    override fun getOutputType(typeFactory: TypeFactory): JavaType = type
-}
 
 /**
  * Currently it is not possible to deduce type of [kotlin.time.Duration] fields therefore explicit annotation is needed on fields in order to properly deserialize POJO.

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/deser/StrictNullChecksTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/_integration/deser/StrictNullChecksTest.kt
@@ -1,5 +1,7 @@
 package io.github.projectmapk.jackson.module.kogera._integration.deser
 
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import io.github.projectmapk.jackson.module.kogera.KotlinFeature
@@ -73,6 +75,40 @@ class StrictNullChecksTest {
         fun map() {
             val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
             assertThrows<MismatchedInputException> { mapper.readValue<MapWrapper>(src) }
+        }
+    }
+
+    class NullsSkipArrayWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: Array<Int>)
+    data class NullsSkipListWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: List<Int>)
+    data class NullsSkipMapWrapper(@JsonSetter(contentNulls = Nulls.SKIP) val value: Map<String, Int>)
+
+    @Nested
+    inner class CustomByAnnotationTest {
+        @Test
+        fun array() {
+            val expected = NullsSkipArrayWrapper(emptyArray())
+            val src = mapper.writeValueAsString(AnyWrapper(arrayOf<Int?>(null)))
+            val result = mapper.readValue<NullsSkipArrayWrapper>(src)
+
+            assertArrayEquals(expected.value, result.value)
+        }
+
+        @Test
+        fun list() {
+            val expected = NullsSkipListWrapper(emptyList())
+            val src = mapper.writeValueAsString(AnyWrapper(listOf<Int?>(null)))
+            val result = mapper.readValue<NullsSkipListWrapper>(src)
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun map() {
+            val expected = NullsSkipMapWrapper(emptyMap())
+            val src = mapper.writeValueAsString(AnyWrapper(mapOf("foo" to null)))
+            val result = mapper.readValue<NullsSkipMapWrapper>(src)
+
+            assertEquals(expected, result)
         }
     }
 }


### PR DESCRIPTION
This will improve performance and use of existing functionality will also improve maintainability.
In addition, error messages have been changed to be more friendly.