### PR TITLE
Update kotlinter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# https://editorconfig.org
+root = true
+
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma = false
+ij_kotlin_allow_trailing_comma_on_call_site = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version kotlinVersion
 
     java
-    id("org.jmailen.kotlinter") version "3.13.0"
+    id("org.jmailen.kotlinter") version "3.16.0"
 }
 
 // Since group cannot be obtained by generateKogeraVersion, it is defined as a constant.


### PR DESCRIPTION
The update to 4.0.0 was difficult to handle due to the amount of changes, so the update was made to 3.16.0.