### PR TITLE
Reduced resource usage when registering the same KotlinModule instance to multiple mappers.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     // test libs
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("io.mockk:mockk:1.13.7")
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ClosedRangeSupport.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ClosedRangeSupport.kt
@@ -42,6 +42,8 @@ internal abstract class ClosedRangeMixin<T> @JsonCreator constructor(
  * As of Kotlin 1.5.32, ClosedRange and ClosedFloatingPointRange are processed.
  */
 internal object ClosedRangeResolver : SimpleAbstractTypeResolver() {
+    private fun readResolve(): Any = ClosedRangeResolver
+
     // At present, it depends on the private class, but if it is made public, it must be switched to a direct reference.
     // see https://youtrack.jetbrains.com/issue/KT-55376
     val closedDoubleRangeRef: Class<*> by lazy {

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ClosedRangeSupport.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ClosedRangeSupport.kt
@@ -3,9 +3,9 @@ package io.github.projectmapk.jackson.module.kogera
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.AbstractTypeResolver
 import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver
 
 internal abstract class ClosedRangeMixin<T> @JsonCreator constructor(
     public val start: T,
@@ -41,7 +41,7 @@ internal abstract class ClosedRangeMixin<T> @JsonCreator constructor(
  * The target of processing is ClosedRange and interfaces or abstract classes that inherit from it.
  * As of Kotlin 1.5.32, ClosedRange and ClosedFloatingPointRange are processed.
  */
-internal object ClosedRangeResolver : AbstractTypeResolver() {
+internal object ClosedRangeResolver : SimpleAbstractTypeResolver() {
     // At present, it depends on the private class, but if it is made public, it must be switched to a direct reference.
     // see https://youtrack.jetbrains.com/issue/KT-55376
     val closedDoubleRangeRef: Class<*> by lazy {

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModule.kt
@@ -71,9 +71,13 @@ public class KotlinModule private constructor(
     )
     public constructor() : this(Builder())
 
+    private val cache: ReflectionCache
+
     init {
         checkMaxCacheSize(maxCacheSize)
         checkCacheSize(initialCacheSize, maxCacheSize)
+
+        cache = ReflectionCache(initialCacheSize, maxCacheSize)
     }
 
     public companion object {
@@ -101,8 +105,6 @@ public class KotlinModule private constructor(
                 "The Jackson Kotlin module requires USE_ANNOTATIONS to be true or it cannot function"
             )
         }
-
-        val cache = ReflectionCache(initialCacheSize, maxCacheSize)
 
         context.addValueInstantiators(
             KotlinInstantiators(cache, nullToEmptyCollection, nullToEmptyMap, nullIsSameAsDefault)

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -6,9 +6,9 @@ import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.deser.Deserializers
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import com.fasterxml.jackson.databind.module.SimpleDeserializers
 import io.github.projectmapk.jackson.module.kogera.JmClass
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
@@ -130,7 +130,7 @@ private fun findValueCreator(type: JavaType, clazz: Class<*>, jmClass: JmClass):
 internal class KotlinDeserializers(
     private val cache: ReflectionCache,
     private val useJavaDurationConversion: Boolean
-) : Deserializers.Base() {
+) : SimpleDeserializers() {
     override fun findBeanDeserializer(
         type: JavaType,
         config: DeserializationConfig?,

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinKeyDeserializers.kt
@@ -33,6 +33,8 @@ internal object ULongKeyDeserializer : StdKeyDeserializer(-1, ULong::class.java)
 }
 
 internal object KotlinKeyDeserializers : SimpleKeyDeserializers() {
+    private fun readResolve(): Any = KotlinKeyDeserializers
+
     override fun findKeyDeserializer(
         type: JavaType,
         config: DeserializationConfig?,

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinKeyDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinKeyDeserializers.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.KeyDeserializer
 import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer
-import com.fasterxml.jackson.databind.deser.std.StdKeyDeserializers
+import com.fasterxml.jackson.databind.module.SimpleKeyDeserializers
 import java.math.BigInteger
 
 // The reason why key is treated as nullable is to match the tentative behavior of StdKeyDeserializer.
@@ -32,7 +32,7 @@ internal object ULongKeyDeserializer : StdKeyDeserializer(-1, ULong::class.java)
         key?.let { ULongChecker.readWithRangeCheck(null, BigInteger(it)) }
 }
 
-internal object KotlinKeyDeserializers : StdKeyDeserializers() {
+internal object KotlinKeyDeserializers : SimpleKeyDeserializers() {
     override fun findKeyDeserializer(
         type: JavaType,
         config: DeserializationConfig?,

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/singletonSupport/KotlinBeanDeserializerModifier.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/singletonSupport/KotlinBeanDeserializerModifier.kt
@@ -6,9 +6,18 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import kotlinx.metadata.Flag
+import java.io.Serializable
 
 // [module-kotlin#225]: keep Kotlin singletons as singletons
-internal class KotlinBeanDeserializerModifier(private val cache: ReflectionCache) : BeanDeserializerModifier() {
+internal class KotlinBeanDeserializerModifier(
+    private val cache: ReflectionCache
+) : BeanDeserializerModifier(), Serializable {
+    companion object {
+        // Increment is required when properties that use LRUMap are changed.
+        @Suppress("ConstPropertyName")
+        private const val serialVersionUID = 1L
+    }
+
     private fun objectSingletonInstance(beanClass: Class<*>): Any? = cache.getJmClass(beanClass)?.let {
         val flags = it.flags
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
@@ -8,11 +8,11 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.deser.SettableBeanProperty
 import com.fasterxml.jackson.databind.deser.ValueInstantiator
-import com.fasterxml.jackson.databind.deser.ValueInstantiators
 import com.fasterxml.jackson.databind.deser.impl.NullsAsEmptyProvider
 import com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer
 import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.databind.module.SimpleValueInstantiators
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.ConstructorValueCreator
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.MethodValueCreator
@@ -113,7 +113,7 @@ internal class KotlinInstantiators(
     private val nullToEmptyCollection: Boolean,
     private val nullToEmptyMap: Boolean,
     private val nullIsSameAsDefault: Boolean
-) : ValueInstantiators {
+) : SimpleValueInstantiators() {
     override fun findValueInstantiator(
         deserConfig: DeserializationConfig,
         beanDescriptor: BeanDescription,

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinKeySerializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinKeySerializers.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.module.SimpleSerializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.ValueClassUnboxConverter
@@ -64,7 +64,7 @@ internal class ValueClassStaticJsonKeySerializer<T : Any>(
     }
 }
 
-internal class KotlinKeySerializers(private val cache: ReflectionCache) : Serializers.Base() {
+internal class KotlinKeySerializers(private val cache: ReflectionCache) : SimpleSerializers() {
     override fun findSerializer(
         config: SerializationConfig,
         type: JavaType,

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinSerializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ser/serializers/KotlinSerializers.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.ser.Serializers
+import com.fasterxml.jackson.databind.module.SimpleSerializers
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.ValueClassUnboxConverter
@@ -67,7 +67,7 @@ internal class ValueClassStaticJsonValueSerializer<T : Any>(
     }
 }
 
-internal class KotlinSerializers(private val cache: ReflectionCache) : Serializers.Base() {
+internal class KotlinSerializers(private val cache: ReflectionCache) : SimpleSerializers() {
     override fun findSerializer(
         config: SerializationConfig?,
         type: JavaType,

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModuleTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinModuleTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class KotlinModuleTest {
     @Test
@@ -78,14 +80,15 @@ class KotlinModuleTest {
         }
     }
 
-    @Test
-    fun jdkSerializabilityTest() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun jdkSerializabilityTest(enabled: Boolean) {
         val module = KotlinModule.Builder().apply {
             withInitialCacheSize(123)
             withMaxCacheSize(321)
 
             KotlinFeature.values().forEach {
-                enable(it)
+                configure(it, enabled)
             }
         }.build()
 


### PR DESCRIPTION
In the past, `KotlinModule` instantiates the support class each time the `setupModule` function is called.
On the other hand, these support classes could be used across multiple `Mapper`s with no problem.
Therefore, I changed them to be initialized only once in a module to reduce resource consumption and improve performance.

In addition, the `SimpleModule` property was used to improve the performance of the initialization process, although only slightly.