### PR TITLE
Refactors

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -75,7 +75,7 @@ internal sealed interface JmClass {
                 companionClass.getAnnotation(Metadata::class.java)!!.accept(this)
             }
 
-            override fun visitFunction(flags: Flags, name: String): KmFunctionVisitor? = KmFunction(flags, name)
+            override fun visitFunction(flags: Flags, name: String): KmFunctionVisitor = KmFunction(flags, name)
                 .apply { functions.add(this) }
         }
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -117,7 +117,7 @@ private class JmClassImpl(
     private val allPropsMap: MutableMap<String, KmProperty> = mutableMapOf()
 
     // Defined as non-lazy because it is always read in both serialization and deserialization
-    final override val properties: List<KmProperty>
+    override val properties: List<KmProperty>
 
     private var companionPropName: String? = null
     override var flags: Flags = flagsOf()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinClassIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinClassIntrospector.kt
@@ -35,6 +35,8 @@ internal class KotlinBeanDescription(coll: POJOPropertiesCollector) : BasicBeanD
 
 // Almost all copies of super @2.14.1
 internal object KotlinClassIntrospector : BasicClassIntrospector() {
+    private fun readResolve(): Any = KotlinClassIntrospector
+
     override fun forSerialization(
         config: SerializationConfig,
         type: JavaType,

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinFeature.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinFeature.kt
@@ -44,7 +44,6 @@ public enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      * Deserializing a singleton overwrites the value of the single instance.
      *
      * See [jackson-module-kotlin#225]: keep Kotlin singletons as singletons.
-     * @see io.github.projectmapk.jackson.module.kogera.SingletonSupport
      */
     SingletonSupport(enabledByDefault = false),
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/JavaToKotlinDurationConverter.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/JavaToKotlinDurationConverter.kt
@@ -9,7 +9,7 @@ import kotlin.time.toKotlinDuration
 /**
  * Currently it is not possible to deduce type of [kotlin.time.Duration] fields therefore explicit annotation is needed on fields in order to properly deserialize POJO.
  *
- * @see [com.fasterxml.jackson.module.kotlin.test.DurationTests]
+ * @see [io.github.projectmapk.jackson.module.kogera.zIntegration.DurationTest]
  */
 internal object JavaToKotlinDurationConverter : StdConverter<JavaDuration, KotlinDuration>() {
     override fun convert(value: JavaDuration) = value.toKotlinDuration()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
@@ -56,6 +56,7 @@ internal class KotlinValueInstantiator(
         buffer: PropertyValueBuffer
     ): Any? {
         val valueCreator: ValueCreator<*> = valueCreator ?: return super.createFromObjectWith(ctxt, props, buffer)
+        valueCreator.checkAccessibility(ctxt)
 
         val bucket = valueCreator.generateBucket()
 
@@ -101,7 +102,6 @@ internal class KotlinValueInstantiator(
             bucket[idx] = paramVal
         }
 
-        valueCreator.checkAccessibility(ctxt)
         return valueCreator.callBy(bucket)
     }
 


### PR DESCRIPTION
- Fixed earlier accessibility checks for creators
- Several KDocs have been corrected
- The `readResolve` of `serializable object` is implemented