### PR TITLE
Migration for `kotlinx-metadata` version upgrade

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -1,7 +1,6 @@
 package io.github.projectmapk.jackson.module.kogera
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
@@ -82,8 +81,6 @@ internal fun String.reconstructClass(): Class<*> {
 
 internal fun KmType.reconstructClassOrNull(): Class<*>? = (classifier as? KmClassifier.Class)
     ?.let { kotlin.runCatching { it.name.reconstructClass() }.getOrNull() }
-
-internal fun KmType.isNullable(): Boolean = Flag.Type.IS_NULLABLE(this.flags)
 
 internal fun AnnotatedElement.hasCreatorAnnotation(): Boolean = getAnnotation(JsonCreator::class.java)
     ?.let { it.mode != JsonCreator.Mode.DISABLED }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -166,7 +166,7 @@ private class JmClassImpl(
 
         // Constructors always have the same name, so only desc is compared
         return constructors.find {
-            val targetDesc = it.signature?.desc
+            val targetDesc = it.signature?.descriptor
             targetDesc == desc || targetDesc == valueDesc
         }
     }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinFallbackAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinFallbackAnnotationIntrospector.kt
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.databind.util.Converter
 import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.annotation.JsonKUnbox
-import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
 import io.github.projectmapk.jackson.module.kogera.ser.KotlinDurationValueToJavaDurationConverter
@@ -23,6 +22,7 @@ import io.github.projectmapk.jackson.module.kogera.ser.KotlinToJavaDurationConve
 import io.github.projectmapk.jackson.module.kogera.ser.SequenceToIteratorConverter
 import kotlinx.metadata.KmTypeProjection
 import kotlinx.metadata.KmValueParameter
+import kotlinx.metadata.isNullable
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -101,7 +101,7 @@ internal class KotlinFallbackAnnotationIntrospector(
     // Determine if the unbox result of value class is nullable
     // @see findNullSerializer
     private fun Class<*>.requireRebox(): Boolean =
-        cache.getJmClass(this)!!.inlineClassUnderlyingType!!.isNullable()
+        cache.getJmClass(this)!!.inlineClassUnderlyingType!!.isNullable
 
     // Perform proper serialization even if the value wrapped by the value class is null.
     // If value is a non-null object type, it must not be reboxing.
@@ -126,7 +126,7 @@ internal class KotlinFallbackAnnotationIntrospector(
 
 private fun KmValueParameter.isNullishTypeAt(index: Int): Boolean = type.arguments.getOrNull(index)?.let {
     // If it is not a StarProjection, type is not null
-    it === KmTypeProjection.STAR || it.type!!.isNullable()
+    it === KmTypeProjection.STAR || it.type!!.isNullable
 } ?: true // If a type argument cannot be taken, treat it as nullable to avoid unexpected failure.
 
 private fun KmValueParameter.requireStrictNullCheck(type: JavaType): Boolean =

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinPrimaryAnnotationIntrospector.kt
@@ -15,13 +15,13 @@ import com.fasterxml.jackson.databind.jsontype.NamedType
 import io.github.projectmapk.jackson.module.kogera.JmClass
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.hasCreatorAnnotation
-import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.reconstructClass
 import io.github.projectmapk.jackson.module.kogera.toSignature
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.KmValueParameter
+import kotlinx.metadata.isNullable
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.setterSignature
 import kotlinx.metadata.jvm.signature
@@ -69,11 +69,11 @@ internal class KotlinPrimaryAnnotationIntrospector(
             // only a check for the existence of a getter is performed.
             // https://youtrack.jetbrains.com/issue/KT-6519
             ?.let {
-                if (it.getterSignature == null) !(it.returnType.isNullable() || type.hasDefaultEmptyValue()) else null
+                if (it.getterSignature == null) !(it.returnType.isNullable || type.hasDefaultEmptyValue()) else null
             }
     }
 
-    private fun KmProperty.isRequiredByNullability(): Boolean = !this.returnType.isNullable()
+    private fun KmProperty.isRequiredByNullability(): Boolean = !this.returnType.isNullable
 
     private fun AnnotatedMethod.getRequiredMarkerFromCorrespondingAccessor(jmClass: JmClass): Boolean? =
         when (parameterCount) {
@@ -99,7 +99,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
         // non required if...
         return when {
             // Argument definition is nullable
-            paramDef.type.isNullable() -> false
+            paramDef.type.isNullable -> false
             // Default argument are defined
             Flag.ValueParameter.DECLARES_DEFAULT_VALUE(paramDef.flags) -> false
             // The conversion in case of null is defined.

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinPrimaryAnnotationIntrospector.kt
@@ -17,11 +17,12 @@ import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.hasCreatorAnnotation
 import io.github.projectmapk.jackson.module.kogera.reconstructClass
 import io.github.projectmapk.jackson.module.kogera.toSignature
-import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmProperty
 import kotlinx.metadata.KmValueParameter
+import kotlinx.metadata.declaresDefaultValue
 import kotlinx.metadata.isNullable
+import kotlinx.metadata.isSecondary
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.setterSignature
 import kotlinx.metadata.jvm.signature
@@ -101,7 +102,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
             // Argument definition is nullable
             paramDef.type.isNullable -> false
             // Default argument are defined
-            Flag.ValueParameter.DECLARES_DEFAULT_VALUE(paramDef.flags) -> false
+            paramDef.declaresDefaultValue -> false
             // The conversion in case of null is defined.
             type.hasDefaultEmptyValue() -> false
             else -> true
@@ -138,7 +139,7 @@ internal class KotlinPrimaryAnnotationIntrospector(
 }
 
 private fun Constructor<*>.isPrimarilyConstructorOf(jmClass: JmClass): Boolean = jmClass.findKmConstructor(this)
-    ?.let { !Flag.Constructor.IS_SECONDARY(it.flags) || jmClass.constructors.size == 1 }
+    ?.let { !it.isSecondary || jmClass.constructors.size == 1 }
     ?: false
 
 private fun KmClassifier.isString(): Boolean = this is KmClassifier.Class && this.name == "kotlin/String"
@@ -152,10 +153,10 @@ private fun isPossibleSingleString(
     javaFunction.parameters[0].annotations.none { it is JsonProperty }
 
 private fun hasCreatorConstructor(clazz: Class<*>, jmClass: JmClass, propertyNames: Set<String>): Boolean {
-    val kmConstructorMap = jmClass.constructors.associateBy { it.signature?.desc }
+    val kmConstructorMap = jmClass.constructors.associateBy { it.signature?.descriptor }
 
     return clazz.constructors.any { constructor ->
-        val kmConstructor = kmConstructorMap[constructor.toSignature().desc] ?: return@any false
+        val kmConstructor = kmConstructorMap[constructor.toSignature().descriptor] ?: return@any false
 
         !isPossibleSingleString(kmConstructor.valueParameters, constructor, propertyNames) &&
             constructor.hasCreatorAnnotation()

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -17,7 +17,7 @@ import io.github.projectmapk.jackson.module.kogera.deser.JavaToKotlinDurationCon
 import io.github.projectmapk.jackson.module.kogera.hasCreatorAnnotation
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.toSignature
-import kotlinx.metadata.Flag
+import kotlinx.metadata.isSecondary
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -115,7 +115,7 @@ private fun invalidCreatorMessage(m: Method): String =
 
 private fun findValueCreator(type: JavaType, clazz: Class<*>, jmClass: JmClass): Method? {
     val primaryKmConstructorSignature =
-        jmClass.constructors.first { !Flag.Constructor.IS_SECONDARY(it.flags) }.signature
+        jmClass.constructors.first { !it.isSecondary }.signature
     var primaryConstructor: Method? = null
 
     clazz.declaredMethods.forEach { method ->

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
@@ -1,18 +1,18 @@
 package io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator
 
-import io.github.projectmapk.jackson.module.kogera.isNullable
 import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.declaresDefaultValue
+import kotlinx.metadata.isNullable
 
 internal class ValueParameter(param: KmValueParameter) {
     val name: String = param.name
     val type: KmType = param.type
     val isOptional: Boolean = param.declaresDefaultValue
     val isPrimitive: Boolean by lazy { type.reconstructClassOrNull()?.isPrimitive == true }
-    val isNullable: Boolean = type.isNullable()
+    val isNullable: Boolean = type.isNullable
     val isGenericType: Boolean = type.classifier is KmClassifier.TypeParameter
 
     // TODO: Formatting into a form that is easy to understand as an error message with reference to KParameter

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
@@ -1,18 +1,19 @@
 package io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator
 
 import io.github.projectmapk.jackson.module.kogera.isNullable
-import kotlinx.metadata.Flag
+import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
+import kotlinx.metadata.declaresDefaultValue
 
 internal class ValueParameter(param: KmValueParameter) {
     val name: String = param.name
     val type: KmType = param.type
-    val isOptional: Boolean = Flag.ValueParameter.DECLARES_DEFAULT_VALUE(param.flags)
-    val isPrimitive: Boolean = Flag.IS_PRIVATE(param.flags)
+    val isOptional: Boolean = param.declaresDefaultValue
+    val isPrimitive: Boolean by lazy { type.reconstructClassOrNull()?.isPrimitive == true }
     val isNullable: Boolean = type.isNullable()
-    val isGenericType: Boolean = param.type.classifier is KmClassifier.TypeParameter
+    val isGenericType: Boolean = type.classifier is KmClassifier.TypeParameter
 
     // TODO: Formatting into a form that is easy to understand as an error message with reference to KParameter
     override fun toString() = "parameter name: $name parameter type: ${type.classifier}"


### PR DESCRIPTION
While all possible modifications were made, modifications regarding difficult-to-address content were not made.

In addition, a bug concerning the `isPrimitive` judgment of `ValueParameter` has been fixed.