### PR TITLE
Removed handling of parameter readout of primitive types

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
@@ -70,7 +70,7 @@ internal class KotlinValueInstantiator(
                 return@forEachIndexed
             }
 
-            var paramVal = if (!isMissing || paramDef.isPrimitive || jsonProp.hasInjectableValueId()) {
+            var paramVal = if (!isMissing || jsonProp.hasInjectableValueId()) {
                 buffer.getParameter(jsonProp).apply {
                     if (this == null && jsonProp.skipNulls() && paramDef.isOptional) return@forEachIndexed
                 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
@@ -34,6 +34,8 @@ internal class KotlinValueInstantiator(
     private fun JavaType.requireEmptyValue() =
         (nullToEmptyCollection && this.isCollectionLikeType) || (nullToEmptyMap && this.isMapLikeType)
 
+    private fun SettableBeanProperty.hasInjectableValueId(): Boolean = injectableValueId != null
+
     private fun SettableBeanProperty.skipNulls(): Boolean =
         nullIsSameAsDefault || (metadata.valueNulls == Nulls.SKIP)
 
@@ -104,8 +106,6 @@ internal class KotlinValueInstantiator(
 
         return valueCreator.callBy(bucket)
     }
-
-    private fun SettableBeanProperty.hasInjectableValueId(): Boolean = injectableValueId != null
 }
 
 internal class KotlinInstantiators(

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
@@ -1,6 +1,5 @@
 package io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator
 
-import io.github.projectmapk.jackson.module.kogera.reconstructClassOrNull
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
@@ -11,7 +10,6 @@ internal class ValueParameter(param: KmValueParameter) {
     val name: String = param.name
     val type: KmType = param.type
     val isOptional: Boolean = param.declaresDefaultValue
-    val isPrimitive: Boolean by lazy { type.reconstructClassOrNull()?.isPrimitive == true }
     val isNullable: Boolean = type.isNullable
     val isGenericType: Boolean = type.classifier is KmClassifier.TypeParameter
 

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/FailNullForPrimitiveTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/FailNullForPrimitiveTest.kt
@@ -1,0 +1,32 @@
+package io.github.projectmapk.jackson.module.kogera.zIntegration.deser
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import io.github.projectmapk.jackson.module.kogera.jacksonObjectMapper
+import io.github.projectmapk.jackson.module.kogera.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+private class FailNullForPrimitiveTest {
+    data class Dto(
+        val foo: Int,
+        val bar: Int?
+    )
+
+    @Test
+    fun test() {
+        val mapper = jacksonObjectMapper()
+            .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+
+        assertThrows<MismatchedInputException> {
+            mapper.readValue<Dto>("{}")
+        }
+
+        assertThrows<MismatchedInputException> {
+            mapper.readValue<Dto>("""{"foo":null}""")
+        }
+
+        assertEquals(Dto(0, null), mapper.readValue<Dto>("""{"foo":0}"""))
+    }
+}


### PR DESCRIPTION
The decision on whether a property definition is `primitive` or not has been removed as it was found to have no effect on the deserialization result.
(Since the first release of `Kogera`, the decision about `isPrimitive` has always been broken, but there was no processing impact.)