### PR TITLE
Fix handling of vararg deserialization.

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -3,7 +3,6 @@ package io.github.projectmapk.jackson.module.kogera
 import com.fasterxml.jackson.annotation.JsonCreator
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
-import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.isNullable
 import kotlinx.metadata.jvm.JvmMethodSignature
 import java.lang.reflect.AnnotatedElement
@@ -56,9 +55,6 @@ internal fun Constructor<*>.toSignature(): JvmMethodSignature =
 
 internal fun Method.toSignature(): JvmMethodSignature =
     JvmMethodSignature(this.name, parameterTypes.toDescBuilder().appendDescriptor(this.returnType).toString())
-
-internal fun List<KmValueParameter>.hasVarargParam(): Boolean =
-    lastOrNull()?.let { it.varargElementType != null } ?: false
 
 internal val defaultConstructorMarker: Class<*> by lazy {
     Class.forName("kotlin.jvm.internal.DefaultConstructorMarker")

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinPrimaryAnnotationIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/annotationIntrospector/KotlinPrimaryAnnotationIntrospector.kt
@@ -103,6 +103,8 @@ internal class KotlinPrimaryAnnotationIntrospector(
             paramDef.type.isNullable -> false
             // Default argument are defined
             paramDef.declaresDefaultValue -> false
+            // vararg is treated as an empty array because undefined input is allowed
+            paramDef.varargElementType != null -> false
             // The conversion in case of null is defined.
             type.hasDefaultEmptyValue() -> false
             else -> true

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
@@ -92,7 +92,7 @@ internal class KotlinValueInstantiator(
                 }
             } else {
                 when {
-                    paramDef.isOptional -> return@forEachIndexed
+                    paramDef.isOptional || paramDef.isVararg -> return@forEachIndexed
                     // do not try to create any object if it is nullable and the value is missing
                     paramDef.isNullable -> null
                     // to get suitable "missing" value provided by deserializer

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucket.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucket.kt
@@ -2,6 +2,7 @@ package io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.argu
 
 import io.github.projectmapk.jackson.module.kogera.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.calcMaskSize
+import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.ValueParameter
 import java.lang.reflect.Array as ReflectArray
 
 private fun defaultPrimitiveValue(type: Class<*>): Any = when (type) {
@@ -20,26 +21,68 @@ private fun defaultPrimitiveValue(type: Class<*>): Any = when (type) {
 private fun defaultEmptyArray(arrayType: Class<*>): Any =
     ReflectArray.newInstance(arrayType.componentType, 0)
 
+// List of Int with only 1 bit enabled.
+private val BIT_FLAGS: List<Int> = IntArray(Int.SIZE_BITS) { (1 shl it).inv() }.asList()
+
+private enum class MaskOperation {
+    // Set argument.
+    SET {
+        override fun invoke(i: Int, j: Int) = i and j
+    },
+
+    // Mark the argument as uninitialized.
+    // A vararg argument that has no default value need not be given and is therefore marked as initialized.
+    INIT {
+        override fun invoke(i: Int, j: Int): Int = i or j.inv()
+    };
+
+    abstract operator fun invoke(i: Int, j: Int): Int
+}
+
+private fun IntArray.update(index: Int, operation: MaskOperation) {
+    val maskIndex = index / Integer.SIZE
+    this[maskIndex] = operation(this[maskIndex], BIT_FLAGS[index % Integer.SIZE])
+}
+
 // @see https://github.com/JetBrains/kotlin/blob/4c925d05883a8073e6732bca95bf575beb031a59/core/reflection.jvm/src/kotlin/reflect/jvm/internal/KCallableImpl.kt#L114
 internal class BucketGenerator(
     parameterTypes: List<Class<*>>,
-    hasVarargParam: Boolean,
+    valueParameters: List<ValueParameter>,
     private val converters: List<ValueClassUnboxConverter<Any>?>
 ) {
     private val valueParameterSize: Int = parameterTypes.size
-    private val originalAbsentArgs: Array<Any?> = Array(valueParameterSize) { i ->
-        // Set values of primitive arguments to the boxed default values (such as 0, 0.0, false) instead of nulls.
-        parameterTypes[i].takeIf { it.isPrimitive }?.let { defaultPrimitiveValue(it) }
-    }
+    private val originalAbsentArgs: Array<Any?>
 
     // -1 is the filled bit mask.
-    private val originalMasks: IntArray = IntArray(calcMaskSize(parameterTypes.size)) { -1 }
+    private val originalMasks: IntArray = IntArray(calcMaskSize(parameterTypes.size)) { 0 }
 
     init {
-        if (hasVarargParam) {
-            // vararg argument is always at the end of the arguments.
-            val i = valueParameterSize - 1
-            originalAbsentArgs[i] = defaultEmptyArray(parameterTypes[i])
+        originalAbsentArgs = Array(valueParameterSize) { i ->
+            val paramType = parameterTypes[i]
+            val metaParam = valueParameters[i]
+
+            when {
+                // In Kotlin, it is possible to define non-tail arguments with vararg,
+                // which cannot be determined by Java reflection, so they are read from Metadata.
+                metaParam.isVararg -> {
+                    // If no default arguments are set,
+                    // the call may be made with an empty array even if no arguments are passed,
+                    // so it is treated as initialized.
+                    // Conversely, if default arguments are set,
+                    // the initial value is treated as uninitialized to detect that no arguments has passed.
+                    if (metaParam.isOptional) originalMasks.update(i, MaskOperation.INIT)
+                    defaultEmptyArray(paramType)
+                }
+                // Set values of primitive arguments to the boxed default values (such as 0, 0.0, false) instead of nulls.
+                paramType.isPrimitive -> {
+                    originalMasks.update(i, MaskOperation.INIT)
+                    defaultPrimitiveValue(paramType)
+                }
+                else -> {
+                    originalMasks.update(i, MaskOperation.INIT)
+                    null
+                }
+            }
         }
     }
 
@@ -53,13 +96,6 @@ internal class ArgumentBucket(
     val masks: IntArray,
     private val converters: List<ValueClassUnboxConverter<Any>?>
 ) {
-    companion object {
-        // List of Int with only 1 bit enabled.
-        private val BIT_FLAGS: List<Int> = IntArray(Int.SIZE_BITS) { (1 shl it).inv() }.asList()
-    }
-
-    private var count = 0
-
     /**
      * Sets the argument corresponding to index.
      * Note that, arguments defined in the value class must be passed as boxed.
@@ -77,8 +113,8 @@ internal class ArgumentBucket(
         val maskIndex = index / Integer.SIZE
         masks[maskIndex] = masks[maskIndex] and BIT_FLAGS[index % Integer.SIZE]
 
-        count++
+        masks.update(index, MaskOperation.SET)
     }
 
-    val isFullInitialized: Boolean get() = count == valueParameterSize
+    val isFullInitialized: Boolean get() = masks.all { it == 0 }
 }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucket.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucket.kt
@@ -53,7 +53,8 @@ internal class BucketGenerator(
     private val valueParameterSize: Int = parameterTypes.size
     private val originalAbsentArgs: Array<Any?>
 
-    // -1 is the filled bit mask.
+    // Mask initialized to 0 when all arguments are set.
+    // The contents are initialized in the init block.
     private val originalMasks: IntArray = IntArray(calcMaskSize(parameterTypes.size)) { 0 }
 
     init {

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ConstructorValueCreator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ConstructorValueCreator.kt
@@ -8,7 +8,6 @@ import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.argum
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.argumentBucket.BucketGenerator
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.calcMaskSize
 import io.github.projectmapk.jackson.module.kogera.getDeclaredConstructorBy
-import io.github.projectmapk.jackson.module.kogera.hasVarargParam
 import java.lang.reflect.Constructor
 
 internal class ConstructorValueCreator<T : Any>(
@@ -33,7 +32,7 @@ internal class ConstructorValueCreator<T : Any>(
         val rawTypes = constructor.parameterTypes.asList()
         bucketGenerator = BucketGenerator(
             rawTypes,
-            constructorParameters.hasVarargParam(),
+            valueParameters,
             constructorParameters.mapToConverters(rawTypes, cache)
         )
     }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/MethodValueCreator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/MethodValueCreator.kt
@@ -7,7 +7,6 @@ import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.argum
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.argumentBucket.BucketGenerator
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.calcMaskSize
 import io.github.projectmapk.jackson.module.kogera.getDeclaredMethodBy
-import io.github.projectmapk.jackson.module.kogera.hasVarargParam
 import kotlinx.metadata.KmFunction
 import java.lang.reflect.Method
 
@@ -33,7 +32,7 @@ internal class MethodValueCreator<T>(
         val rawTypes = method.parameterTypes.asList()
         bucketGenerator = BucketGenerator(
             rawTypes,
-            kmParameters.hasVarargParam(),
+            valueParameters,
             kmParameters.mapToConverters(rawTypes, cache)
         )
     }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ValueParameter.kt
@@ -11,6 +11,7 @@ internal class ValueParameter(param: KmValueParameter) {
     val type: KmType = param.type
     val isOptional: Boolean = param.declaresDefaultValue
     val isNullable: Boolean = type.isNullable
+    val isVararg: Boolean = param.varargElementType != null
     val isGenericType: Boolean = type.classifier is KmClassifier.TypeParameter
 
     // TODO: Formatting into a form that is easy to understand as an error message with reference to KParameter

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucketTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucketTest.kt
@@ -4,7 +4,6 @@ import io.github.projectmapk.jackson.module.kogera.ValueClassUnboxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.ValueParameter
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/HasRequiredMarkerTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/HasRequiredMarkerTest.kt
@@ -27,12 +27,13 @@ class HasRequiredMarkerTest {
             .build()
     )
 
-    data class ConstructorParamTarget(
+    class ConstructorParamTarget(
         val nullable: String?,
         val hasDefault: String = "default",
         val collection: Collection<*>,
         val map: Map<*, *>,
-        val nonNull: Any
+        val nonNull: Any,
+        vararg val vararg: Int
     )
 
     @Nested
@@ -46,6 +47,7 @@ class HasRequiredMarkerTest {
             assertTrue(desc.isRequired("collection"))
             assertTrue(desc.isRequired("map"))
             assertTrue(desc.isRequired("nonNull"))
+            assertFalse(desc.isRequired("vararg"))
         }
 
         @Test
@@ -57,6 +59,7 @@ class HasRequiredMarkerTest {
             assertFalse(desc.isRequired("collection"))
             assertFalse(desc.isRequired("map"))
             assertTrue(desc.isRequired("nonNull"))
+            assertFalse(desc.isRequired("vararg"))
         }
     }
 
@@ -113,7 +116,7 @@ class HasRequiredMarkerTest {
         }
     }
 
-    data class AnnotationTarget(
+    class AnnotationTarget(
         @param:JsonProperty(required = true)
         val nullableParam: String?,
         @param:JsonProperty(required = true)
@@ -121,7 +124,9 @@ class HasRequiredMarkerTest {
         @param:JsonProperty(required = true)
         val collectionParam: Collection<*>,
         @param:JsonProperty(required = true)
-        val mapParam: Map<*, *>
+        val mapParam: Map<*, *>,
+        @param:JsonProperty(required = true)
+        vararg val vararg: Int
     ) {
         @set:JsonProperty(required = true)
         var nullableProp: String? = null
@@ -153,6 +158,7 @@ class HasRequiredMarkerTest {
         assertTrue(desc.isRequired("hasDefaultParam"))
         assertTrue(desc.isRequired("collectionParam"))
         assertTrue(desc.isRequired("mapParam"))
+        assertTrue(desc.isRequired("vararg"))
 
         assertTrue(desc.isRequired("nullableProp"))
         assertTrue(desc.isRequired("nullableField"))
@@ -167,7 +173,8 @@ class HasRequiredMarkerTest {
         val hasDefault: String,
         val collection: Collection<*>,
         val map: Map<*, *>,
-        val nonNull: Any
+        val nonNull: Any,
+        val vararg: List<Int>
     ) {
         companion object {
             @JvmStatic
@@ -177,13 +184,14 @@ class HasRequiredMarkerTest {
                 hasDefault: String = "default",
                 collection: Collection<*>,
                 map: Map<*, *>,
-                nonNull: Any
-            ) = FactoryParamTarget(nullable, hasDefault, collection, map, nonNull)
+                nonNull: Any,
+                vararg vararg: Int
+            ) = FactoryParamTarget(nullable, hasDefault, collection, map, nonNull, vararg.asList())
         }
     }
 
     @Nested
-    inner class ParamTest {
+    inner class FactoryParamTest {
         @Test
         fun defaultParam() {
             val desc = defaultMapper.introspectDeser<FactoryParamTarget>()
@@ -193,6 +201,7 @@ class HasRequiredMarkerTest {
             assertTrue(desc.isRequired("collection"))
             assertTrue(desc.isRequired("map"))
             assertTrue(desc.isRequired("nonNull"))
+            assertFalse(desc.isRequired("vararg"))
         }
 
         @Test
@@ -204,14 +213,16 @@ class HasRequiredMarkerTest {
             assertFalse(desc.isRequired("collection"))
             assertFalse(desc.isRequired("map"))
             assertTrue(desc.isRequired("nonNull"))
+            assertFalse(desc.isRequired("vararg"))
         }
     }
 
-    data class FactoryAnnotationTarget(
+    class FactoryAnnotationTarget(
         val nullableParam: String?,
         val hasDefaultParam: String = "default",
         val collectionParam: Collection<*>,
-        val mapParam: Map<*, *>
+        val mapParam: Map<*, *>,
+        val vararg: List<Int>
     ) {
         companion object {
             @JvmStatic
@@ -224,8 +235,10 @@ class HasRequiredMarkerTest {
                 @JsonProperty(required = true)
                 collectionParam: Collection<*>,
                 @JsonProperty(required = true)
-                mapParam: Map<*, *>
-            ) = FactoryAnnotationTarget(nullableParam, hasDefaultParam, collectionParam, mapParam)
+                mapParam: Map<*, *>,
+                @JsonProperty(required = true)
+                vararg vararg: Int
+            ) = FactoryAnnotationTarget(nullableParam, hasDefaultParam, collectionParam, mapParam, vararg.asList())
         }
     }
 
@@ -237,5 +250,6 @@ class HasRequiredMarkerTest {
         assertTrue(desc.isRequired("hasDefaultParam"))
         assertTrue(desc.isRequired("collectionParam"))
         assertTrue(desc.isRequired("mapParam"))
+        assertTrue(desc.isRequired("vararg"))
     }
 }

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/VarargTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/VarargTest.kt
@@ -1,0 +1,110 @@
+package io.github.projectmapk.jackson.module.kogera.zIntegration.deser
+
+import io.github.projectmapk.jackson.module.kogera.jacksonObjectMapper
+import io.github.projectmapk.jackson.module.kogera.readValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class VarargTest {
+    val mapper = jacksonObjectMapper()
+
+    class OnlyVararg(vararg val v: Int)
+
+    @Nested
+    inner class OnlyVarargTest {
+        @Test
+        fun hasArgs() {
+            val r = mapper.readValue<OnlyVararg>("""{"v":[1,2,3]}""")
+            assertEquals(listOf(1, 2, 3), r.v.asList())
+        }
+
+        @Test
+        fun empty() {
+            val r = mapper.readValue<OnlyVararg>("""{"v":[]}""")
+            assertTrue(r.v.isEmpty())
+        }
+
+        @Test
+        fun undefined() {
+            val r = mapper.readValue<OnlyVararg>("""{}""")
+            assertTrue(r.v.isEmpty())
+        }
+    }
+
+    class HeadVararg(vararg val v: Int?, val i: Int)
+
+    @Nested
+    inner class HeadVarargTest {
+        @Test
+        fun hasArgs() {
+            val r = mapper.readValue<HeadVararg>("""{"i":0,"v":[1,2,null]}""")
+            assertEquals(listOf(1, 2, null), r.v.asList())
+            assertEquals(0, r.i)
+        }
+
+        @Test
+        fun empty() {
+            val r = mapper.readValue<HeadVararg>("""{"i":0,"v":[]}""")
+            assertTrue(r.v.isEmpty())
+            assertEquals(0, r.i)
+        }
+
+        @Test
+        fun undefined() {
+            val r = mapper.readValue<HeadVararg>("""{"i":0}""")
+            assertTrue(r.v.isEmpty())
+            assertEquals(0, r.i)
+        }
+    }
+
+    class TailVararg(val i: Int, vararg val v: String)
+
+    @Nested
+    inner class TailVarargTest {
+        @Test
+        fun hasArgs() {
+            val r = mapper.readValue<TailVararg>("""{"i":0,"v":["foo","bar","baz"]}""")
+            assertEquals(listOf("foo", "bar", "baz"), r.v.asList())
+            assertEquals(0, r.i)
+        }
+
+        @Test
+        fun empty() {
+            val r = mapper.readValue<TailVararg>("""{"i":0,"v":[]}""")
+            assertTrue(r.v.isEmpty())
+            assertEquals(0, r.i)
+        }
+
+        @Test
+        fun undefined() {
+            val r = mapper.readValue<TailVararg>("""{"i":0}""")
+            assertTrue(r.v.isEmpty())
+            assertEquals(0, r.i)
+        }
+    }
+
+    class HasDefaultVararg(vararg val v: String? = arrayOf("foo", "bar"))
+
+    @Nested
+    inner class HasDefaultVarargTest {
+        @Test
+        fun hasArgs() {
+            val r = mapper.readValue<HasDefaultVararg>("""{"v":["foo","bar",null]}""")
+            assertEquals(listOf("foo", "bar", null), r.v.asList())
+        }
+
+        @Test
+        fun empty() {
+            val r = mapper.readValue<HasDefaultVararg>("""{"v":[]}""")
+            assertTrue(r.v.isEmpty())
+        }
+
+        @Test
+        fun undefined() {
+            val r = mapper.readValue<HasDefaultVararg>("""{}""")
+            assertEquals(listOf("foo", "bar"), r.v.asList())
+        }
+    }
+}


### PR DESCRIPTION
Previously, if the input to a `vararg` parameter was `undefined`, deserialization would fail.
This is because `vararg` parameters were treated the same as `non-null` array.

`Kogera` improves this handling as follows.

- If `undefined` is entered for `vararg`, an empty array is set if no default argument is available.
  - Do not make deserialization fail.
- For deserialization, mark `vararg` as `non-required`.

### Implementation changes to `ArgumentBucket`
This PR makes major changes to the `ArgumentBucket`.

The most significant change is that `vararg` arguments, which have no default argument set, are now treated as initialized and can be overridden.
This makes it impossible to check that an `ArgumentBucket` is fully initialized just by the count of `set` invoked.

Therefore, the implementation policy has been changed to check that all `mask`s are set to 0.
This policy increases the initialization cost a little, but the cost of each call is minimal.