### PR TITLE
Tweaks related to `value class` support in deserialization

### DIFF
--- a/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/WrapsNullableValueClassDeserializer.java
+++ b/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/WrapsNullableValueClassDeserializer.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
  * An interface to be inherited by JsonDeserializer that handles value classes that may wrap nullable.
  * @see WrapsNullableValueClassBoxDeserializer for implementation.
  */
-// To ensure maximum compatibility with StdDeserializer, this class is defined in Java.
+// To ensure maximum compatibility with StdDeserializer, this class is written in Java.
 public abstract class WrapsNullableValueClassDeserializer<D> extends StdDeserializer<D> {
     protected WrapsNullableValueClassDeserializer(@NotNull KClass<?> vc) {
         super(JvmClassMappingKt.getJavaClass(vc));

--- a/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/WrapsNullableValueClassDeserializer.java
+++ b/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/WrapsNullableValueClassDeserializer.java
@@ -1,5 +1,8 @@
 package io.github.projectmapk.jackson.module.kogera.deser;
 
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.github.projectmapk.jackson.module.kogera.deser.deserializers.WrapsNullableValueClassBoxDeserializer;
@@ -7,6 +10,8 @@ import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KClass;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
 
 /**
  * An interface to be inherited by JsonDeserializer that handles value classes that may wrap nullable.
@@ -44,4 +49,8 @@ public abstract class WrapsNullableValueClassDeserializer<D> extends StdDeserial
     // It is defined so that null can also be returned so that Nulls.SKIP can be applied.
     @Nullable
     public abstract D getBoxedNullValue();
+
+    @Override
+    public abstract D deserialize(@NotNull JsonParser p, @NotNull DeserializationContext ctxt)
+            throws IOException, JacksonException;
 }

--- a/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/WrapsNullableValueClassDeserializer.java
+++ b/src/main/java/io/github/projectmapk/jackson/module/kogera/deser/WrapsNullableValueClassDeserializer.java
@@ -2,7 +2,7 @@ package io.github.projectmapk.jackson.module.kogera.deser;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import io.github.projectmapk.jackson.module.kogera.deser.deserializers.ValueClassBoxDeserializer;
+import io.github.projectmapk.jackson.module.kogera.deser.deserializers.WrapsNullableValueClassBoxDeserializer;
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KClass;
 import org.jetbrains.annotations.NotNull;
@@ -10,23 +10,23 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * An interface to be inherited by JsonDeserializer that handles value classes that may wrap nullable.
- * @see ValueClassBoxDeserializer for implementation.
+ * @see WrapsNullableValueClassBoxDeserializer for implementation.
  */
 // To ensure maximum compatibility with StdDeserializer, this class is defined in Java.
-public abstract class ValueClassDeserializer<D> extends StdDeserializer<D> {
-    protected ValueClassDeserializer(@NotNull KClass<?> vc) {
+public abstract class WrapsNullableValueClassDeserializer<D> extends StdDeserializer<D> {
+    protected WrapsNullableValueClassDeserializer(@NotNull KClass<?> vc) {
         super(JvmClassMappingKt.getJavaClass(vc));
     }
 
-    protected ValueClassDeserializer(@NotNull Class<?> vc) {
+    protected WrapsNullableValueClassDeserializer(@NotNull Class<?> vc) {
         super(vc);
     }
 
-    protected ValueClassDeserializer(@NotNull JavaType valueType) {
+    protected WrapsNullableValueClassDeserializer(@NotNull JavaType valueType) {
         super(valueType);
     }
 
-    protected ValueClassDeserializer(@NotNull StdDeserializer<D> src) {
+    protected WrapsNullableValueClassDeserializer(@NotNull StdDeserializer<D> src) {
         super(src);
     }
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Converters.kt
@@ -29,7 +29,6 @@ internal class ValueClassUnboxConverter<T : Any>(val valueClass: Class<T>) : Std
     private val unboxMethod = valueClass.getDeclaredMethod("unbox-impl").apply {
         if (!this.isAccessible) this.isAccessible = true
     }
-    val unboxedClass: Class<*> = unboxMethod.returnType
 
     override fun convert(value: T): Any? = unboxMethod.invoke(value)
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -14,7 +14,7 @@ import io.github.projectmapk.jackson.module.kogera.KotlinDuration
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
 import io.github.projectmapk.jackson.module.kogera.ValueClassBoxConverter
 import io.github.projectmapk.jackson.module.kogera.deser.JavaToKotlinDurationConverter
-import io.github.projectmapk.jackson.module.kogera.deser.ValueClassDeserializer
+import io.github.projectmapk.jackson.module.kogera.deser.WrapsNullableValueClassDeserializer
 import io.github.projectmapk.jackson.module.kogera.hasCreatorAnnotation
 import io.github.projectmapk.jackson.module.kogera.isUnboxableValueClass
 import io.github.projectmapk.jackson.module.kogera.toSignature
@@ -89,10 +89,10 @@ internal object ULongDeserializer : StdDeserializer<ULong>(ULong::class.java) {
         ULongChecker.readWithRangeCheck(p, p.bigIntegerValue)
 }
 
-internal class ValueClassBoxDeserializer<S, D : Any>(
+internal class WrapsNullableValueClassBoxDeserializer<S, D : Any>(
     private val creator: Method,
     private val converter: ValueClassBoxConverter<S, D>
-) : ValueClassDeserializer<D>(converter.boxedClass) {
+) : WrapsNullableValueClassDeserializer<D>(converter.boxedClass) {
     private val inputType: Class<*> = creator.parameterTypes[0]
 
     init {
@@ -171,7 +171,7 @@ internal class KotlinDeserializers(
             rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)?.let {
                 val unboxedClass = cache.getValueClassUnboxConverter(rawClass).unboxedClass
                 val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass)
-                ValueClassBoxDeserializer(it, converter)
+                WrapsNullableValueClassBoxDeserializer(it, converter)
             }
             else -> null
         }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/deserializers/KotlinDeserializers.kt
@@ -169,7 +169,7 @@ internal class KotlinDeserializers(
             rawClass == KotlinDuration::class.java ->
                 JavaToKotlinDurationConverter.takeIf { useJavaDurationConversion }?.delegatingDeserializer
             rawClass.isUnboxableValueClass() -> findValueCreator(type, rawClass, cache.getJmClass(rawClass)!!)?.let {
-                val unboxedClass = cache.getValueClassUnboxConverter(rawClass).unboxedClass
+                val unboxedClass = it.returnType
                 val converter = cache.getValueClassBoxConverter(unboxedClass, rawClass)
                 WrapsNullableValueClassBoxDeserializer(it, converter)
             }

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/KotlinValueInstantiator.kt
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
 import com.fasterxml.jackson.databind.exc.InvalidNullException
 import com.fasterxml.jackson.databind.module.SimpleValueInstantiators
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
-import io.github.projectmapk.jackson.module.kogera.deser.ValueClassDeserializer
+import io.github.projectmapk.jackson.module.kogera.deser.WrapsNullableValueClassDeserializer
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.ConstructorValueCreator
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.MethodValueCreator
 import io.github.projectmapk.jackson.module.kogera.deser.valueInstantiator.creator.ValueCreator
@@ -47,7 +47,7 @@ internal class KotlinValueInstantiator(
         isNullableParam: Boolean,
         valueDeserializer: JsonDeserializer<*>?
     ): Boolean = !isNullableParam &&
-        valueDeserializer is ValueClassDeserializer<*> &&
+        valueDeserializer is WrapsNullableValueClassDeserializer<*> &&
         cache.getJmClass(valueDeserializer.handledType())!!.wrapsNullValueClass()
 
     private val valueCreator: ValueCreator<*>? by ReflectProperties.lazySoft {
@@ -83,7 +83,7 @@ internal class KotlinValueInstantiator(
                     // Deserializer.getNullValue could not be used because there is no way to get and parse parameters
                     // from the BeanDescription and using AnnotationIntrospector would override user customization.
                     if (requireValueClassSpecialNullValue(paramDef.isNullable, valueDeserializer)) {
-                        (valueDeserializer as ValueClassDeserializer<*>).boxedNullValue?.let { return@run it }
+                        (valueDeserializer as WrapsNullableValueClassDeserializer<*>).boxedNullValue?.let { return@run it }
                     }
 
                     if (jsonProp.skipNulls() && paramDef.isOptional) return@forEachIndexed

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/NullableObjectEdgeCases.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/NullableObjectEdgeCases.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
-import io.github.projectmapk.jackson.module.kogera.deser.ValueClassDeserializer
+import io.github.projectmapk.jackson.module.kogera.deser.WrapsNullableValueClassDeserializer
 import io.github.projectmapk.jackson.module.kogera.jacksonObjectMapper
 import io.github.projectmapk.jackson.module.kogera.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -42,7 +42,7 @@ class NullableObjectEdgeCases {
         assertEquals(NullValue(NullValueDeserializer.nv, NullValueDeserializer.nv), result)
     }
 
-    class NullsSkipDeserializer : ValueClassDeserializer<VC>(VC::class) {
+    class NullsSkipDeserializerWrapsNullable : WrapsNullableValueClassDeserializer<VC>(VC::class) {
         override fun deserialize(p: JsonParser, ctxt: DeserializationContext): VC {
             TODO("Not yet implemented")
         }
@@ -52,7 +52,7 @@ class NullableObjectEdgeCases {
 
     data class NullsSkip(
         @field:JsonSetter(nulls = Nulls.SKIP)
-        @field:JsonDeserialize(using = NullsSkipDeserializer::class)
+        @field:JsonDeserialize(using = NullsSkipDeserializerWrapsNullable::class)
         val nn: VC = VC("skip"),
         @field:JsonSetter(nulls = Nulls.SKIP)
         val n: VC? = VC("skip")

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/ValueClasses.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/ValueClasses.kt
@@ -3,7 +3,7 @@ package io.github.projectmapk.jackson.module.kogera.zIntegration.deser.valueClas
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import io.github.projectmapk.jackson.module.kogera.deser.ValueClassDeserializer
+import io.github.projectmapk.jackson.module.kogera.deser.WrapsNullableValueClassDeserializer
 
 @JvmInline
 value class Primitive(val v: Int) {
@@ -22,7 +22,7 @@ value class NonNullObject(val v: String) {
 
 @JvmInline
 value class NullableObject(val v: String?) {
-    class Deserializer : ValueClassDeserializer<NullableObject>(NullableObject::class) {
+    class DeserializerWrapsNullable : WrapsNullableValueClassDeserializer<NullableObject>(NullableObject::class) {
         override fun deserialize(p: JsonParser, ctxt: DeserializationContext): NullableObject =
             NullableObject(p.valueAsString + "-deser")
 

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/deserializer/SpecifiedForObjectMapperTest.kt
@@ -17,7 +17,7 @@ class SpecifiedForObjectMapperTest {
             val module = SimpleModule().apply {
                 this.addDeserializer(Primitive::class.java, Primitive.Deserializer())
                 this.addDeserializer(NonNullObject::class.java, NonNullObject.Deserializer())
-                this.addDeserializer(NullableObject::class.java, NullableObject.Deserializer())
+                this.addDeserializer(NullableObject::class.java, NullableObject.DeserializerWrapsNullable())
             }
             this.registerModule(module)
         }

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/deserializer/byAnnotation/specifiedForProperty/NullableObjectTest.kt
@@ -14,9 +14,9 @@ class NullableObjectTest {
     }
 
     data class NonNull(
-        @get:JsonDeserialize(using = NullableObject.Deserializer::class)
+        @get:JsonDeserialize(using = NullableObject.DeserializerWrapsNullable::class)
         val getterAnn: NullableObject,
-        @field:JsonDeserialize(using = NullableObject.Deserializer::class)
+        @field:JsonDeserialize(using = NullableObject.DeserializerWrapsNullable::class)
         val fieldAnn: NullableObject
     )
 
@@ -34,9 +34,9 @@ class NullableObjectTest {
     }
 
     data class Nullable(
-        @get:JsonDeserialize(using = NullableObject.Deserializer::class)
+        @get:JsonDeserialize(using = NullableObject.DeserializerWrapsNullable::class)
         val getterAnn: NullableObject?,
-        @field:JsonDeserialize(using = NullableObject.Deserializer::class)
+        @field:JsonDeserialize(using = NullableObject.DeserializerWrapsNullable::class)
         val fieldAnn: NullableObject?
     )
 

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/jsonCreator/HandledByJacksonTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zIntegration/deser/valueClass/jsonCreator/HandledByJacksonTest.kt
@@ -9,38 +9,38 @@ import org.junit.jupiter.api.Test
 // Test for Creator that can be handled by the Jackson mechanism.
 class HandledByJacksonTest {
     @JvmInline
-    value class PrimitiveNullableCreator(val value: Int) {
+    value class PrimitiveMultiParamCreator(val value: Int) {
         companion object {
             // Avoiding unboxing by making the return value of Creator nullable
             @JvmStatic
             @JsonCreator
-            fun creator(first: Int, second: Int): PrimitiveNullableCreator? =
-                PrimitiveNullableCreator(first + second)
+            fun creator(first: Int, second: Int): PrimitiveMultiParamCreator? =
+                PrimitiveMultiParamCreator(first + second)
         }
     }
 
     @Test
     fun primitiveNullableCreatorTest() {
         val mapper = jacksonObjectMapper()
-        val r: PrimitiveNullableCreator = mapper.readValue("""{"first":1,"second":2}""")
-        assertEquals(PrimitiveNullableCreator(3), r)
+        val r: PrimitiveMultiParamCreator = mapper.readValue("""{"first":1,"second":2}""")
+        assertEquals(PrimitiveMultiParamCreator(3), r)
     }
 
     @JvmInline
-    value class NullableObjectNullableCreator(val value: Int?) {
+    value class NullableObjectMiltiParamCreator(val value: Int?) {
         companion object {
             // Avoiding unboxing by making the return value of Creator nullable
             @JvmStatic
             @JsonCreator
-            fun creator(first: Int, second: Int): NullableObjectNullableCreator? =
-                NullableObjectNullableCreator(first + second)
+            fun creator(first: Int, second: Int): NullableObjectMiltiParamCreator? =
+                NullableObjectMiltiParamCreator(first + second)
         }
     }
 
     @Test
     fun nullableObjectNullableCreatorTest() {
         val mapper = jacksonObjectMapper()
-        val r: NullableObjectNullableCreator = mapper.readValue("""{"first":1,"second":2}""")
-        assertEquals(NullableObjectNullableCreator(3), r)
+        val r: NullableObjectMiltiParamCreator = mapper.readValue("""{"first":1,"second":2}""")
+        assertEquals(NullableObjectMiltiParamCreator(3), r)
     }
 }


### PR DESCRIPTION
Fixed minor flaws discovered through the porting process to `jackson-module-kotlin`.

- Changed the name of `ValueClassDeserializer` to `WrapsNullableValueClassDeserializer`.
  - This is because it was thought to be misleading that it should be used for other than `value class` that wraps nullables.
- Changed to use the return value of the creator when initializing the deserializer of `value class`.
  - This is because there was no problem with this form as long as the target is handled by `KotlinModule`.
  - However, since `unboxConverter` is used by `Instantiator`, the initialization cost does not change much.