### PR TITLE
Modified to not use deprecated API

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -1,5 +1,6 @@
 package io.github.projectmapk.jackson.module.kogera
 
+import kotlinx.metadata.ClassKind
 import kotlinx.metadata.ClassName
 import kotlinx.metadata.ExperimentalContextReceivers
 import kotlinx.metadata.Flags
@@ -18,7 +19,6 @@ import kotlinx.metadata.KmTypeParameterVisitor
 import kotlinx.metadata.KmTypeVisitor
 import kotlinx.metadata.KmVariance
 import kotlinx.metadata.KmVersionRequirementVisitor
-import kotlinx.metadata.flagsOf
 import kotlinx.metadata.internal.accept
 import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmProtoBufUtil
 import kotlinx.metadata.jvm.getterSignature
@@ -26,6 +26,7 @@ import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Constructor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import kotlinx.metadata.internal.metadata.deserialization.Flags as ProtoFlags
 
 // KmClassVisitor with all processing disabled as much as possible to reduce load
 internal sealed class ReducedKmClassVisitor : KmClassVisitor() {
@@ -95,7 +96,7 @@ internal sealed interface JmClass {
         }
     }
 
-    val flags: Flags
+    val kind: ClassKind
     val constructors: List<KmConstructor>
     val sealedSubclasses: List<ClassName>
     val inlineClassUnderlyingType: KmType?
@@ -120,7 +121,7 @@ private class JmClassImpl(
     override val properties: List<KmProperty>
 
     private var companionPropName: String? = null
-    override var flags: Flags = flagsOf()
+    override lateinit var kind: ClassKind
     override val constructors: MutableList<KmConstructor> = mutableListOf()
     override val sealedSubclasses: MutableList<ClassName> = mutableListOf()
     override var inlineClassUnderlyingType: KmType? = null
@@ -181,7 +182,7 @@ private class JmClassImpl(
 
     // KmClassVisitor
     override fun visit(flags: Flags, name: ClassName) {
-        this.flags = flags
+        kind = ClassKind.values()[ProtoFlags.CLASS_KIND.get(flags).number]
     }
 
     override fun visitProperty(flags: Flags, name: String, getterFlags: Flags, setterFlags: Flags): KmPropertyVisitor =

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/singletonSupport/KotlinBeanDeserializerModifier.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/singletonSupport/KotlinBeanDeserializerModifier.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationConfig
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
 import io.github.projectmapk.jackson.module.kogera.ReflectionCache
-import kotlinx.metadata.Flag
+import kotlinx.metadata.ClassKind
 import java.io.Serializable
 
 // [module-kotlin#225]: keep Kotlin singletons as singletons
@@ -19,10 +19,8 @@ internal class KotlinBeanDeserializerModifier(
     }
 
     private fun objectSingletonInstance(beanClass: Class<*>): Any? = cache.getJmClass(beanClass)?.let {
-        val flags = it.flags
-
         // It is not assumed that the companion object is the target
-        if (Flag.Class.IS_OBJECT(flags) && !Flag.Class.IS_COMPANION_OBJECT(flags)) {
+        if (it.kind == ClassKind.OBJECT) {
             beanClass.getDeclaredField("INSTANCE").get(null)
         } else {
             null


### PR DESCRIPTION
from: https://github.com/JetBrains/kotlin/blob/e1df52bc0255d24651141f5a2094d3ab7e61d4d2/libraries/kotlinx-metadata/src/kotlinx/metadata/Attributes.kt#L120 https://github.com/JetBrains/kotlin/blob/e1df52bc0255d24651141f5a2094d3ab7e61d4d2/libraries/kotlinx-metadata/src/kotlinx/metadata/internal/FlagDelegatesImpl.kt#L26