### PR TITLE
Update `kotlinx-metadata-jvm`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junit = "5.10.1"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
-kotlinx-metadata-jvm = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.7.0"
+kotlinx-metadata-jvm = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.9.0"
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/InternalCommons.kt
@@ -1,16 +1,22 @@
 package io.github.projectmapk.jackson.module.kogera
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmClassifier
 import kotlinx.metadata.KmType
 import kotlinx.metadata.isNullable
 import kotlinx.metadata.jvm.JvmMethodSignature
+import kotlinx.metadata.jvm.KotlinClassMetadata
 import java.lang.reflect.AnnotatedElement
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 
 internal typealias JavaDuration = java.time.Duration
 internal typealias KotlinDuration = kotlin.time.Duration
+
+internal fun Class<*>.toKmClass(): KmClass? = getAnnotation(Metadata::class.java)?.let {
+    (KotlinClassMetadata.readStrict(it) as KotlinClassMetadata.Class).kmClass
+}
 
 internal fun Class<*>.isUnboxableValueClass() = this.isAnnotationPresent(JvmInline::class.java)
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/JmClass.kt
@@ -1,26 +1,15 @@
+// Visitor API has already been deprecated, but the error is being suppressed for now.
+@file:Suppress("DEPRECATION_ERROR")
+
 package io.github.projectmapk.jackson.module.kogera
 
 import kotlinx.metadata.ClassKind
 import kotlinx.metadata.ClassName
-import kotlinx.metadata.ExperimentalContextReceivers
-import kotlinx.metadata.Flags
-import kotlinx.metadata.KmClassExtensionVisitor
-import kotlinx.metadata.KmClassVisitor
+import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmConstructor
-import kotlinx.metadata.KmConstructorVisitor
-import kotlinx.metadata.KmExtensionType
 import kotlinx.metadata.KmFunction
-import kotlinx.metadata.KmFunctionVisitor
 import kotlinx.metadata.KmProperty
-import kotlinx.metadata.KmPropertyVisitor
 import kotlinx.metadata.KmType
-import kotlinx.metadata.KmTypeAliasVisitor
-import kotlinx.metadata.KmTypeParameterVisitor
-import kotlinx.metadata.KmTypeVisitor
-import kotlinx.metadata.KmVariance
-import kotlinx.metadata.KmVersionRequirementVisitor
-import kotlinx.metadata.internal.accept
-import kotlinx.metadata.internal.metadata.jvm.deserialization.JvmProtoBufUtil
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Constructor
@@ -28,62 +17,13 @@ import java.lang.reflect.Field
 import java.lang.reflect.Method
 import kotlinx.metadata.internal.metadata.deserialization.Flags as ProtoFlags
 
-// KmClassVisitor with all processing disabled as much as possible to reduce load
-internal sealed class ReducedKmClassVisitor : KmClassVisitor() {
-    final override val delegate: KmClassVisitor? get() = null
-
-    // from KmDeclarationContainerVisitor
-    override fun visitFunction(flags: Flags, name: String): KmFunctionVisitor? = null
-    override fun visitProperty(
-        flags: Flags,
-        name: String,
-        getterFlags: Flags,
-        setterFlags: Flags
-    ): KmPropertyVisitor? = null
-    override fun visitTypeAlias(flags: Flags, name: String): KmTypeAliasVisitor? = null
-    override fun visitExtensions(type: KmExtensionType): KmClassExtensionVisitor? = null
-
-    // from KmClassVisitor
-    override fun visit(flags: Flags, name: ClassName) {}
-    override fun visitTypeParameter(
-        flags: Flags,
-        name: String,
-        id: Int,
-        variance: KmVariance
-    ): KmTypeParameterVisitor? = null
-    override fun visitSupertype(flags: Flags): KmTypeVisitor? = null
-    override fun visitConstructor(flags: Flags): KmConstructorVisitor? = null
-    override fun visitCompanionObject(name: String) {}
-    override fun visitNestedClass(name: String) {}
-    override fun visitEnumEntry(name: String) {}
-    override fun visitSealedSubclass(name: ClassName) {}
-    override fun visitInlineClassUnderlyingPropertyName(name: String) {}
-    override fun visitInlineClassUnderlyingType(flags: Flags): KmTypeVisitor? = null
-
-    @OptIn(ExperimentalContextReceivers::class)
-    override fun visitContextReceiverType(flags: Flags): KmTypeVisitor? = null
-    override fun visitVersionRequirement(): KmVersionRequirementVisitor? = null
-    override fun visitEnd() {}
-}
-
 // Jackson Metadata Class
 internal sealed interface JmClass {
     class CompanionObject(declaringClass: Class<*>, companionObject: String) {
-        private class ReducedCompanionVisitor(companionClass: Class<*>) : ReducedKmClassVisitor() {
-            val functions: MutableList<KmFunction> = arrayListOf()
-
-            init {
-                companionClass.getAnnotation(Metadata::class.java)!!.accept(this)
-            }
-
-            override fun visitFunction(flags: Flags, name: String): KmFunctionVisitor = KmFunction(flags, name)
-                .apply { functions.add(this) }
-        }
-
         private val companionField: Field = declaringClass.getDeclaredField(companionObject)
         val type: Class<*> = companionField.type
         val isAccessible: Boolean = companionField.isAccessible
-        private val functions by lazy { ReducedCompanionVisitor(type).functions }
+        private val functions by lazy { type.toKmClass()!!.functions }
         val instance: Any by lazy {
             // To prevent the call from failing, save the initial value and then rewrite the flag.
             if (!companionField.isAccessible) companionField.isAccessible = true
@@ -111,34 +51,35 @@ internal sealed interface JmClass {
 
 private class JmClassImpl(
     clazz: Class<*>,
-    metadata: Metadata,
+    kmClass: KmClass,
     superJmClass: JmClass?,
     interfaceJmClasses: List<JmClass>
-) : ReducedKmClassVisitor(), JmClass {
-    private val allPropsMap: MutableMap<String, KmProperty> = mutableMapOf()
+) : JmClass {
+    private val allPropsMap: Map<String, KmProperty>
 
     // Defined as non-lazy because it is always read in both serialization and deserialization
     override val properties: List<KmProperty>
 
-    private var companionPropName: String? = null
-    override lateinit var kind: ClassKind
-    override val constructors: MutableList<KmConstructor> = mutableListOf()
-    override val sealedSubclasses: MutableList<ClassName> = mutableListOf()
-    override var inlineClassUnderlyingType: KmType? = null
+    private val companionPropName: String? = kmClass.companionObject
+    override val kind: ClassKind = ClassKind.values()[ProtoFlags.CLASS_KIND.get(kmClass.flags).number]
+    override val constructors: List<KmConstructor> = kmClass.constructors
+    override val sealedSubclasses: List<ClassName> = kmClass.sealedSubclasses
+    override val inlineClassUnderlyingType: KmType? = kmClass.inlineClassUnderlyingType
 
     init {
-        metadata.accept(this)
-
         // Add properties of inherited classes and interfaces
         // If an `interface` is implicitly implemented by an abstract class,
         // it is necessary to obtain a more specific type, so always add it from the abstract class first.
-        (superJmClass as JmClassImpl?)?.allPropsMap?.forEach {
-            this.allPropsMap.putIfAbsent(it.key, it.value)
+        val tempPropsMap = ((superJmClass as JmClassImpl?)?.allPropsMap?.toMutableMap() ?: mutableMapOf()).apply {
+            kmClass.properties.forEach {
+                this[it.name] = it
+            }
         }
-        @Suppress("UNCHECKED_CAST")
-        (interfaceJmClasses as List<JmClassImpl>).forEach { i ->
-            i.allPropsMap.forEach {
-                this.allPropsMap.putIfAbsent(it.key, it.value)
+
+        allPropsMap = interfaceJmClasses.fold(tempPropsMap) { acc, cur ->
+            val curProps = (cur as JmClassImpl).allPropsMap
+            acc.apply {
+                curProps.forEach { acc.putIfAbsent(it.key, it.value) }
             }
         }
 
@@ -179,38 +120,11 @@ private class JmClassImpl(
         val getterName = getter.name
         return properties.find { it.getterSignature?.name == getterName }
     }
-
-    // KmClassVisitor
-    override fun visit(flags: Flags, name: ClassName) {
-        kind = ClassKind.values()[ProtoFlags.CLASS_KIND.get(flags).number]
-    }
-
-    override fun visitProperty(flags: Flags, name: String, getterFlags: Flags, setterFlags: Flags): KmPropertyVisitor =
-        KmProperty(flags, name, getterFlags, setterFlags).apply { allPropsMap[name] = this }
-
-    override fun visitConstructor(flags: Flags): KmConstructorVisitor =
-        KmConstructor(flags).apply { constructors.add(this) }
-
-    override fun visitCompanionObject(name: String) {
-        this.companionPropName = name
-    }
-
-    override fun visitSealedSubclass(name: ClassName) {
-        sealedSubclasses.add(name)
-    }
-
-    override fun visitInlineClassUnderlyingType(flags: Flags): KmTypeVisitor =
-        KmType(flags).also { inlineClassUnderlyingType = it }
-}
-
-private fun Metadata.accept(visitor: ReducedKmClassVisitor) {
-    val (strings, proto) = JvmProtoBufUtil.readClassDataFrom(data1.takeIf(Array<*>::isNotEmpty)!!, data2)
-    proto.accept(visitor, strings)
 }
 
 internal fun JmClass(
     clazz: Class<*>,
-    metadata: Metadata,
+    kmClass: KmClass,
     superJmClass: JmClass?,
     interfaceJmClasses: List<JmClass>
-): JmClass = JmClassImpl(clazz, metadata, superJmClass, interfaceJmClasses)
+): JmClass = JmClassImpl(clazz, kmClass, superJmClass, interfaceJmClasses)

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/ReflectionCache.kt
@@ -48,7 +48,7 @@ internal class ReflectionCache(initialCacheSize: Int, maxCacheSize: Int) : Seria
 
     fun getJmClass(clazz: Class<*>): JmClass? {
         return find(clazz) ?: run {
-            val metadata = clazz.getAnnotation(Metadata::class.java) ?: return null
+            val kmClass = clazz.toKmClass() ?: return null
 
             // Do not parse super class for interfaces.
             val superJmClass = if (!clazz.isInterface) {
@@ -61,7 +61,7 @@ internal class ReflectionCache(initialCacheSize: Int, maxCacheSize: Int) : Seria
             }
             val interfaceJmClasses = clazz.interfaces.mapNotNull { getJmClass(it) }
 
-            val value = JmClass(clazz, metadata, superJmClass, interfaceJmClasses)
+            val value = JmClass(clazz, kmClass, superJmClass, interfaceJmClasses)
             putIfAbsent(clazz, value)
         }
     }


### PR DESCRIPTION
Fixed a compatibility issue with a higher version of `kotlinx-metadata-jvm` caused by a destructive change.
However, this degraded initialization performance.