### PR TITLE
Removal of useless processing

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucket.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/argumentBucket/ArgumentBucket.kt
@@ -111,9 +111,6 @@ internal class ArgumentBucket(
         // Since there is no multiple initialization in the use case, the key check is omitted.
         arguments[index] = actualArg
 
-        val maskIndex = index / Integer.SIZE
-        masks[maskIndex] = masks[maskIndex] and BIT_FLAGS[index % Integer.SIZE]
-
         masks.update(index, MaskOperation.SET)
     }
 


### PR DESCRIPTION
It was a code that was forgotten to erase the process during the transition of the method.