### PR TITLE
Organize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ First, by implementing the equivalent of https://github.com/FasterXML/jackson-mo
 The cache has also been reorganized based on [benchmark results](https://github.com/ProjectMapK/kogera-benchmark) to achieve smaller memory consumption.  
 The performance degradation when the `strictNullChecks` option is enabled is also [greatly reduced](https://github.com/ProjectMapK/jackson-module-kogera/pull/44).
 
-The next main feature is `value class` support.  
-The `jackson-module-kogera` supports many use cases for `value class`, including deserialization.  
-See [here](./docs/AboutValueClassSupport.md) for basic policies and notes on handling `value class`.
-
 [Here](./docs/FixedIssues.md) is a list of issues that are not resolved in `jackson-module-kotlin` but are or will be resolved in `kogera`.
 
 ## About intentional destructive changes

--- a/docs/FixedIssues.md
+++ b/docs/FixedIssues.md
@@ -1,15 +1,12 @@
 A list of issues that have not been resolved in `jackson-module-kotlin`, but have been or will be resolved in `kogera`.
 
 ## Fixed
-- [Support for inline classes · Issue \#199](https://github.com/FasterXML/jackson-module-kotlin/issues/199)
 - [Getting MismatchedInputException instead of MissingKotlinParameterException · Issue \#234](https://github.com/FasterXML/jackson-module-kotlin/issues/234)
 - [Private getter with different return type hides property · Issue \#341](https://github.com/FasterXML/jackson-module-kotlin/issues/341)
 - [Remove \`kotlin\-reflect\` and replace it with \`kotlinx\-metadata\-jvm\` · Issue \#450](https://github.com/FasterXML/jackson-module-kotlin/issues/450)
-- [Supports deserialization of \`value class\` \(\`inline class\`\)\. · Issue \#650](https://github.com/FasterXML/jackson-module-kotlin/issues/650)
 - [Annotation given to constructor parameters containing \`value class\` as argument does not work · Issue \#651](https://github.com/FasterXML/jackson-module-kotlin/issues/651)
 - [How to deserialize a kotlin\.ranges\.ClosedRange<T> with Jackson · Issue \#663](https://github.com/FasterXML/jackson-module-kotlin/issues/663)
 - [There are cases where \`isRequired\` specifications are not properly merged\. · Issue \#668](https://github.com/FasterXML/jackson-module-kotlin/issues/668)
 
 ## Want to fix
 - [There are some problems with KNAI\.hasCreatorAnnotation · Issue \#547](https://github.com/FasterXML/jackson-module-kotlin/issues/547)
-- [This module shouldn't bring kotlin\-reflect 1\.5 as a transitive dependency · Issue \#566](https://github.com/FasterXML/jackson-module-kotlin/issues/566)

--- a/docs/KogeraSpecificImplementations.md
+++ b/docs/KogeraSpecificImplementations.md
@@ -25,7 +25,3 @@ I will consider making the classes public again when we receive requests for the
 ## Remove old options and `deprecated` code
 Because `jackson-module-kotlin` is a framework with a long history, some old code and options remain.  
 In `kogera`, those options have been removed.
-
-# Value class support
-The `jackson-module-kogera` supports many use cases of `value class` (`inline class`).  
-This is summarized [here](./AboutValueClassSupport.md).


### PR DESCRIPTION
Since value class support was added to the original in 2.17, the reference to kogera-specific was removed.