### PR TITLE
Removed references to Issue that is no longer actually corrected

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.22" />
+    <option name="version" value="1.9.25" />
   </component>
 </project>

--- a/docs/FixedIssues.md
+++ b/docs/FixedIssues.md
@@ -2,7 +2,6 @@ A list of issues that have not been resolved in `jackson-module-kotlin`, but hav
 
 ## Fixed
 - [Getting MismatchedInputException instead of MissingKotlinParameterException · Issue \#234](https://github.com/FasterXML/jackson-module-kotlin/issues/234)
-- [Private getter with different return type hides property · Issue \#341](https://github.com/FasterXML/jackson-module-kotlin/issues/341)
 - [Remove \`kotlin\-reflect\` and replace it with \`kotlinx\-metadata\-jvm\` · Issue \#450](https://github.com/FasterXML/jackson-module-kotlin/issues/450)
 - [Annotation given to constructor parameters containing \`value class\` as argument does not work · Issue \#651](https://github.com/FasterXML/jackson-module-kotlin/issues/651)
 - [How to deserialize a kotlin\.ranges\.ClosedRange<T> with Jackson · Issue \#663](https://github.com/FasterXML/jackson-module-kotlin/issues/663)


### PR DESCRIPTION
With the 2.15.2-beta3 fix, the Java style getter is no longer ignored, so https://github.com/FasterXML/jackson-module-kotlin/issues/341 is back.
https://github.com/ProjectMapK/jackson-module-kogera/releases/tag/2.15.2-beta3

Since this is an edge case and can be handled by the user, I will not consider addressing this Issue.