### PR TITLE
Add GitHub Actions to dependabot's management target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,20 @@
 version: 2
 
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "19:00"
+      timezone: "Asia/Tokyo"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
-      # Friday 19:00 JST
-      day: "saturday"
-      time: "04:00"
+      day: "friday"
+      time: "19:00"
+      timezone: "Asia/Tokyo"
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
At the same time, time zone management was corrected to JST.