### PR TITLE
Change option defaults to match the planned changes for Jackson 3.0

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinFeature.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinFeature.kt
@@ -45,7 +45,7 @@ public enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      *
      * See [jackson-module-kotlin#225]: keep Kotlin singletons as singletons.
      */
-    SingletonSupport(enabledByDefault = false),
+    SingletonSupport(enabledByDefault = true),
 
     /**
      * This feature represents whether to check deserialized collections.
@@ -56,7 +56,7 @@ public enum class KotlinFeature(internal val enabledByDefault: Boolean) {
      *
      * Also, if contentNulls are custom from findSetterInfo in AnnotationIntrospector, there may be a conflict.
      */
-    StrictNullChecks(enabledByDefault = false),
+    StrictNullChecks(enabledByDefault = true),
 
     /**
      * This feature represents whether to include in Jackson's parsing the annotations given to the parameters of

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/KotlinModuleTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/KotlinModuleTest.kt
@@ -23,8 +23,8 @@ class KotlinModuleTest {
         assertFalse(module.nullToEmptyCollection)
         assertFalse(module.nullToEmptyMap)
         assertFalse(module.nullIsSameAsDefault)
-        assertEquals(module.singletonSupport, false)
-        assertFalse(module.strictNullChecks)
+        assertTrue(module.singletonSupport)
+        assertTrue(module.strictNullChecks)
     }
 
     @Test
@@ -35,8 +35,8 @@ class KotlinModuleTest {
         assertFalse(module.nullToEmptyCollection)
         assertFalse(module.nullToEmptyMap)
         assertFalse(module.nullIsSameAsDefault)
-        assertEquals(false, module.singletonSupport)
-        assertFalse(module.strictNullChecks)
+        assertTrue(module.singletonSupport)
+        assertTrue(module.strictNullChecks)
     }
 
     @Test

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/test/github/Github27.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/test/github/Github27.kt
@@ -3,6 +3,7 @@ package io.github.projectmapk.jackson.module.kogera.zPorted.test.github
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import io.github.projectmapk.jackson.module.kogera.KotlinFeature
 import io.github.projectmapk.jackson.module.kogera.jacksonObjectMapper
 import io.github.projectmapk.jackson.module.kogera.readValue
 import io.github.projectmapk.jackson.module.kogera.zPorted.test.expectFailure
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 
 class TestGithub27 {
-    val mapper: ObjectMapper = jacksonObjectMapper()
+    val mapper: ObjectMapper = jacksonObjectMapper { disable(KotlinFeature.StrictNullChecks) }
         .configure(SerializationFeature.INDENT_OUTPUT, false)
 
     private data class ClassWithNullableInt(val sample: Int?)

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/test/github/failing/Github518.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/test/github/failing/Github518.kt
@@ -1,5 +1,6 @@
 package io.github.projectmapk.jackson.module.kogera.zPorted.test.github.failing
 
+import io.github.projectmapk.jackson.module.kogera.KotlinFeature
 import io.github.projectmapk.jackson.module.kogera.KotlinFeature.SingletonSupport
 import io.github.projectmapk.jackson.module.kogera.jacksonObjectMapper
 import io.github.projectmapk.jackson.module.kogera.jsonMapper
@@ -30,7 +31,7 @@ class TestGithub518 {
     @Test
     fun deserializeEmptyObjectToSingletonUnitFails() {
         expectFailure<AssertionError>("GitHub #518 has been fixed!") {
-            assertSame(jacksonObjectMapper().readValue<Unit?>("{}"), Unit)
+            assertSame(jacksonObjectMapper { disable(SingletonSupport) }.readValue<Unit?>("{}"), Unit)
         }
     }
 


### PR DESCRIPTION
Relates to https://github.com/FasterXML/jackson-module-kotlin/issues/870

The following two options are now enabled by default

- `StrictNullChecks`
- `SingletonSupport`