### PR TITLE
Added type match check to readValues

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Extensions.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/Extensions.kt
@@ -82,10 +82,19 @@ internal inline fun <reified T> Any?.checkTypeMismatch(): T {
 public inline fun <reified T> ObjectMapper.readValue(jp: JsonParser): T = readValue(jp, jacksonTypeRef<T>())
     .checkTypeMismatch()
 
-// TODO: After importing 2.19, import the changes in kotlin-module and uncomment the tests.
-public inline fun <reified T> ObjectMapper.readValues(
-    jp: JsonParser
-): MappingIterator<T> = readValues(jp, jacksonTypeRef<T>())
+/**
+ * Shorthand for [ObjectMapper.readValues].
+ * @throws RuntimeJsonMappingException Especially if [T] is non-null and the value read is null.
+ *   Other cases where the read value is of a different type than [T]
+ *   due to an incorrect customization to [ObjectMapper].
+ */
+public inline fun <reified T> ObjectMapper.readValues(jp: JsonParser): MappingIterator<T> {
+    val values = readValues(jp, jacksonTypeRef<T>())
+
+    return object : MappingIterator<T>(values) {
+        override fun nextValue(): T = super.nextValue().checkTypeMismatch()
+    }
+}
 
 /**
  * Shorthand for [ObjectMapper.readValue].

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/ReadValuesTest.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/ReadValuesTest.kt
@@ -38,9 +38,7 @@ class ReadValuesTest {
             val itr = mapper.readValues<String>(src)
 
             assertEquals("foo", itr.next())
-            // TODO: It is expected to be checked after importing 2.19.
-            // assertThrows<RuntimeJsonMappingException> {
-            assertDoesNotThrow {
+            assertThrows<RuntimeJsonMappingException> {
                 itr.next()
             }
         }
@@ -51,9 +49,7 @@ class ReadValuesTest {
             val itr = mapper.readValues<String>(src)
 
             assertEquals("foo", itr.nextValue())
-            // TODO: It is expected to be checked after importing 2.19.
-            // assertThrows<RuntimeJsonMappingException> {
-            assertDoesNotThrow {
+            assertThrows<RuntimeJsonMappingException> {
                 itr.nextValue()
             }
         }


### PR DESCRIPTION
from https://github.com/FasterXML/jackson-module-kotlin/pull/937
What could not be ported at #295
Fixes #296