### PR TITLE
Fixed to not generate fields

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ConstructorValueCreator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/ConstructorValueCreator.kt
@@ -20,7 +20,7 @@ internal class ConstructorValueCreator<T : Any>(
     private val declaringClass: Class<T> = constructor.declaringClass
 
     override val isAccessible: Boolean = constructor.isAccessible
-    override val callableName: String = constructor.name
+    override val callableName: String get() = constructor.name
     override val valueParameters: List<JmValueParameter>
     override val bucketGenerator: BucketGenerator
 

--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/MethodValueCreator.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/deser/valueInstantiator/creator/MethodValueCreator.kt
@@ -19,7 +19,7 @@ internal class MethodValueCreator<T>(
 ) : ValueCreator<T>() {
     private val companion: JmClass.CompanionObject = declaringJmClass.companion!!
     override val isAccessible: Boolean = method.isAccessible && companion.isAccessible
-    override val callableName: String = method.name
+    override val callableName: String get() = method.name
     override val valueParameters: List<JmValueParameter>
     override val bucketGenerator: BucketGenerator
 


### PR DESCRIPTION
Since this property is only used to display error messages, it is expected to reduce initialization costs and the amount of memory used constantly.