### PR TITLE
Update Kotlin to 2.1.21

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -42,7 +42,7 @@ jobs:
         # LTS versions, latest version (if exists)
         java-version: [ '17', '21', '24' ]
         # Minimum version, latest release version, latest pre-release version (if exists)
-        kotlin: ['2.0.21', '2.1.21', '2.2.20']
+        kotlin: ['2.1.21', '2.2.20']
     env:
       KOTLIN_VERSION: ${{ matrix.kotlin }}
     name: "Kotlin ${{ matrix.kotlin }} - Java ${{ matrix.java-version }}"

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="version" value="2.1.21" />
   </component>
 </project>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,4 +22,4 @@ jackson-csv = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-cs
 jackson-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
 
 [plugins]
-kotlinter = { id = "org.jmailen.kotlinter", version = "5.0.2" }
+kotlinter = { id = "org.jmailen.kotlinter", version = "5.1.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.21" # Mainly for CI, it can be rewritten by environment variable.
+kotlin = "2.1.21" # Mainly for CI, it can be rewritten by environment variable.
 jackson = "2.20.0"
 
 # test libs


### PR DESCRIPTION
CI fails when using Java 25 with Kotlin 2.0.x.