### PR TITLE
Fix "missing" custom ClassIntrospector after ObjectMapper::copy

### DIFF
--- a/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinClassIntrospector.kt
+++ b/src/main/kotlin/io/github/projectmapk/jackson/module/kogera/KotlinClassIntrospector.kt
@@ -37,6 +37,8 @@ internal class KotlinBeanDescription(coll: POJOPropertiesCollector) : BasicBeanD
 internal object KotlinClassIntrospector : BasicClassIntrospector() {
     private fun readResolve(): Any = KotlinClassIntrospector
 
+    override fun copy(): KotlinClassIntrospector = this
+
     override fun forSerialization(
         config: SerializationConfig,
         type: JavaType,


### PR DESCRIPTION
Adds copy() to KotlinClassIntrospector

There is a problem with objectMapper.copy() method with kogera module. Copy method of ObjectMapper does not call setupModule method in SimpleModule in copy. It calls ClassIntrospector.copy() method instead.