### PR TITLE
Update Kotlin versions in test workflow

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -42,7 +42,7 @@ jobs:
         # LTS versions, latest version (if exists)
         java-version: [ '17', '21', '25', '26' ]
         # Minimum version, latest release version, latest pre-release version (if exists)
-        kotlin: ['2.1.21', '2.2.21', '2.3.20']
+        kotlin: ['2.1.21', '2.2.21', '2.3.21', '2.4.0-Beta2']
     env:
       KOTLIN_VERSION: ${{ matrix.kotlin }}
     name: "Kotlin ${{ matrix.kotlin }} - Java ${{ matrix.java-version }}"

--- a/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/test/github/failing/Github474.kt
+++ b/src/test/kotlin/io/github/projectmapk/jackson/module/kogera/zPorted/test/github/failing/Github474.kt
@@ -7,16 +7,24 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class TestGithub474 {
+    open class Parent(@JsonProperty("parent-prop") val parent: String)
+    class Child(@JsonProperty("child-prop") val child: String) : Parent(child)
+
     @Test
     fun jsonPropertyAnnotationRespectedOnParentClass() {
-        open class Parent(@JsonProperty("parent-prop") val parent: String)
-        class Child(@JsonProperty("child-prop") val child: String) : Parent(child)
-
-        expectFailure<AssertionError>("GitHub #474 has been fixed!") {
+        val assertion = {
             assertEquals(
                 """{"child-prop":"foo","parent-prop":"foo"}""",
                 defaultMapper.writeValueAsString(Child("foo"))
             )
+        }
+
+        if (KotlinVersion(2, 4) <= KotlinVersion.CURRENT) {
+            assertion()
+        } else {
+            expectFailure<AssertionError>("GitHub #474 has been fixed!") {
+                assertion()
+            }
         }
     }
 }


### PR DESCRIPTION
Updated Kotlin versions in the workflow matrix to include 2.3.21 and 2.4.0-Beta2.