### PR TITLE
Pin Jackson to the 2.21 LTS line in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,5 +28,11 @@ updates:
       # The version of Kotlin is fixed to the lowest, so it is not subject to automatic updates
       - dependency-name: "kotlin"
       - dependency-name: "kotlin-metadata-jvm"
+      # Jackson 2.x has two LTS lines (2.21 and 2.22), and this project is based on the 2.21 line.
+      # Only patch updates within 2.21 are accepted (2.22.0 is treated as a minor update).
+      - dependency-name: "com.fasterxml.jackson:jackson-bom"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       # linter is not subject to automatic renewal as it will be migrated to detekt in the future
       - dependency-name: "org.jmailen.kotlinter"


### PR DESCRIPTION
## What

Configures Dependabot so that `jackson-bom` stays on the **2.21 LTS line**.

```yaml
- dependency-name: com.fasterxml.jackson:jackson-bom
  update-types:
    - version-update:semver-major
    - version-update:semver-minor
```

## Why

Jackson 2.x currently maintains two LTS lines, 2.21 and 2.22. This project is based on 2.21 for now, but Dependabot proposed 2.21.5 -> 2.22.1 in #442, which had to be reverted by hand.

The metadata of that PR reported the bump as:

- `dependency-name: com.fasterxml.jackson:jackson-bom`
- `update-type: version-update:semver-minor`

So the `21` part of `2.21.x` is treated as the semver minor. Ignoring major/minor updates leaves only patch updates (e.g. 2.21.5 -> 2.21.6) subject to automatic renewal.

## Notes

- The dependency name is the module coordinate `com.fasterxml.jackson:jackson-bom`, not the version catalog alias `jackson`. It is the only Jackson entry in the catalog that carries a version; the rest are managed by the BOM, so a single rule is enough.
- Combining this with the existing `dependencies` group (`patterns: *`) is fine, Jackson minor/major updates are simply excluded from the group PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)