### PR TITLE
Make Kotlin subject to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,15 @@ updates:
         patterns:
           - "*"
     ignore:
-      # The version of Kotlin is fixed to the lowest, so it is not subject to automatic updates
-      - dependency-name: "kotlin"
-      - dependency-name: "kotlin-metadata-jvm"
+      # Kotlin is fixed to the lowest supported version, so only patch updates are accepted.
+      - dependency-name: "org.jetbrains.kotlin:*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "org.jetbrains.kotlin.jvm*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       # Jackson 2.x has two LTS lines (2.21 and 2.22), and this project is based on the 2.21 line.
       # Only patch updates within 2.21 are accepted (2.22.0 is treated as a minor update).
       - dependency-name: "com.fasterxml.jackson:jackson-bom"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     `maven-publish` // for JitPack
 
-    val kotlinVersion: String = System.getenv("KOTLIN_VERSION")?.takeIf { it.isNotEmpty() }
-        ?: libs.versions.kotlin.get()
-
-    kotlin("jvm") version kotlinVersion
+    alias(libs.plugins.kotlin.jvm)
 
     java
     alias(libs.plugins.kotlinter)
@@ -25,10 +22,8 @@ repositories {
 }
 
 dependencies {
-    val kotlinVersion: String = System.getenv("KOTLIN_VERSION")?.takeIf { it.isNotEmpty() }
-        ?: libs.versions.kotlin.get()
-    implementation("${libs.kotlin.stdlib.get()}:${kotlinVersion}")
-    implementation("${libs.kotlin.metadata.jvm.get()}:${kotlinVersion}")
+    // kotlin-stdlib is added automatically by the Kotlin Gradle Plugin, as in the official Kotlin libraries.
+    implementation(libs.kotlin.metadata.jvm)
 
     implementation(platform(libs.jackson.bom))
     api(libs.jackson.databind)
@@ -41,7 +36,7 @@ dependencies {
 
     testImplementation(libs.mockk)
 
-    testImplementation("${libs.kotlin.reflect.get()}:${kotlinVersion}")
+    testImplementation(libs.kotlin.reflect)
     testImplementation(libs.jackson.xml)
     testImplementation(libs.jackson.csv)
     testImplementation(libs.jackson.jsr310)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,19 @@
 [versions]
-kotlin = "2.1.21" # Mainly for CI, it can be rewritten by environment variable.
+kotlin = "2.1.21" # The lowest supported version. Mainly for CI, it can be rewritten by environment variable.
 jackson = "2.21.5"
 
 # test libs
 junit = "6.1.2"
 
 [libraries]
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
-kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm" }
+kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
 
 # test libs
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 mockk = "io.mockk:mockk:1.14.11"
 jackson-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml" }
@@ -22,4 +21,5 @@ jackson-csv = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-cs
 jackson-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
 
 [plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "5.1.1" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,11 @@
 rootProject.name = "jackson-module-kogera"
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        // gradle/libs.versions.toml is imported automatically, so only the overrides are declared here.
+        create("libs") {
+            // Mainly for CI, it can be rewritten by environment variable.
+            System.getenv("KOTLIN_VERSION")?.takeIf { it.isNotEmpty() }?.let { version("kotlin", it) }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`[versions] kotlin` was not referenced by any catalog entry, so Dependabot could not resolve its coordinates and has never proposed an update for it. The existing ignore rules pointed at catalog aliases (`kotlin`, `kotlin-metadata-jvm`), which do not match Dependabot's dependency names either. Kotlin was not "ignored" — it was never detected in the first place.

## Changes

- Reference `versions.kotlin` from the Kotlin library entries and add the Kotlin Gradle Plugin to `[plugins]`, so that a single alias drives every Kotlin artifact.
- Move the `KOTLIN_VERSION` override into the version catalog (`settings.gradle.kts`). Adding `version.ref` breaks the previous `"${libs.kotlin.stdlib.get()}:${kotlinVersion}"` form, and overriding the alias keeps the declarations in `build.gradle.kts` plain.
- Replace the ineffective ignore rules with the same policy as Jackson: patch updates are accepted, minor/major updates are applied explicitly.
- Stop declaring `kotlin-stdlib` explicitly, following the official Kotlin libraries.

## About kotlin-stdlib

`kotlinx-coroutines`, `kotlinx-serialization`, `kotlinx-datetime`, `kotlinx-io` and `kotlinx.collections.immutable` declare no `kotlin-stdlib` dependency and set no `kotlin.stdlib.default.dependency`; they leave it to the Kotlin Gradle Plugin. Their published POMs, along with those of `kotlin-metadata-jvm` and `kotlin-reflect`, all carry `kotlin-stdlib` at `compile` scope.

This project declared it explicitly via `implementation`, which published it at `runtime` scope. Removing the declaration aligns both the build script and the published POM with those libraries.

**This changes the published artifact**: `kotlin-stdlib` moves from `runtime` to `compile` scope.

## Verification

| Check | Result |
|---|---|
| `./gradlew clean lintKotlin test` | BUILD SUCCESSFUL |
| `KOTLIN_VERSION=2.3.21 ./gradlew test` | BUILD SUCCESSFUL |
| Kotlin Gradle Plugin resolution (default / `2.2.21` / `2.4.20-Beta1`) | `2.1.21` / `2.2.21` / `2.4.20-Beta1` |
| POM (default) | `kotlin-stdlib` `2.1.21` / `compile` |
| POM (`KOTLIN_VERSION=2.3.21`) | `kotlin-stdlib` `2.3.21` / `compile` |

`kotlin-stdlib`, `kotlin-metadata-jvm`, `kotlin-reflect` and `kotlin-gradle-plugin` all publish the same 2.1.x version set (`2.1.0 2.1.10 2.1.20 2.1.21`), so sharing a single `version.ref` cannot produce an unresolvable combination.

## Note

The minimum Kotlin version in `test-main.yml` is still hardcoded as `2.1.21`, so it needs to be kept in sync manually if Dependabot bumps `[versions] kotlin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
