### PR TITLE
Build published releases on JitPack

### DIFF
--- a/.github/actions/warmup-jitpack/action.yml
+++ b/.github/actions/warmup-jitpack/action.yml
@@ -1,0 +1,22 @@
+name: warmup-jitpack
+description: Starts a JitPack build for the given tag and verifies that the artifact is published.
+
+inputs:
+  tag:
+    description: "Tag to build on JitPack (e.g. 2.21.5-beta38)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+        base="https://jitpack.io/com/github/${GITHUB_REPOSITORY}/${TAG}"
+        # JitPack builds on demand. Requesting the log starts the build and streams its output,
+        # so that the first consumer of a new version does not have to wait for it.
+        curl -fsSL --max-time 900 "${base}/build.log" | tail -n 50
+        # The log alone does not reliably report the result, so the artifact itself is requested.
+        curl -fsS --max-time 60 -o /dev/null "${base}/${GITHUB_REPOSITORY#*/}-${TAG}.pom"

--- a/.github/workflows/warmup-jitpack.yml
+++ b/.github/workflows/warmup-jitpack.yml
@@ -1,0 +1,31 @@
+name: warmup-jitpack
+# Builds every published release on JitPack, so that failures surface here
+# rather than being hit by the first consumer of the version.
+# The build itself lives in .github/actions/warmup-jitpack, because a release
+# created with GITHUB_TOKEN never triggers another workflow run; a workflow that
+# publishes a release on its own has to run that action directly instead.
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build on JitPack (e.g. 2.21.5-beta38)"
+        required: true
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  warmup-jitpack:
+    name: warmup-jitpack
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Warm up JitPack
+        uses: ./.github/actions/warmup-jitpack
+        with:
+          tag: ${{ inputs.tag || github.event.release.tag_name }}


### PR DESCRIPTION
## Problem

JitPack builds on demand: pushing a tag does nothing, and the build only starts when someone first requests that version. So the first consumer of a new release waits several minutes for the build, and if the build fails, that consumer is the one who finds out. Nothing on our side notices.

## Changes

A workflow triggered by `release: published` requests the build log, which starts the build on JitPack and streams its output. The log alone does not reliably report the result, so the artifact is requested afterwards to confirm that it was actually published.

```bash
base="https://jitpack.io/com/github/${GITHUB_REPOSITORY}/${TAG}"
curl -fsSL --max-time 900 "${base}/build.log" | tail -n 50
curl -fsS --max-time 60 -o /dev/null "${base}/${GITHUB_REPOSITORY#*/}-${TAG}.pom"
```

`workflow_dispatch` with a tag input is available as well, for versions released before this workflow existed.

## Why a composite action

A release created with `GITHUB_TOKEN` never triggers another workflow run, so a workflow that publishes a release on its own cannot rely on the release event. Keeping the build in `.github/actions/warmup-jitpack` lets such a workflow run it directly rather than duplicating the requests.

## Note

This has not been exercised against JitPack yet — it can only run for real once a release is published. The URL layout is the one that currently serves `2.21.5-beta37`:

```
https://jitpack.io/com/github/ProjectMapK/jackson-module-kogera/2.21.5-beta37/jackson-module-kogera-2.21.5-beta37.pom
```

If the first run fails, `workflow_dispatch` can be used to retry against an existing tag without cutting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
