### PR TITLE
Release for every supported Jackson line

### DIFF
--- a/.github/workflows/release-jackson-lines.yml
+++ b/.github/workflows/release-jackson-lines.yml
@@ -1,0 +1,128 @@
+name: release-jackson-lines
+# Releases the same source for every supported Jackson minor line.
+# Triggered by publishing a release (e.g. 2.21.5-beta38), it creates a commit that
+# rewrites only the Jackson version in the version catalog, then tags it as
+# <latest patch of the line>-<same beta number> so JitPack can build it.
+# The tag is pushed only after the tests pass, so a line that is incompatible
+# with the current source is simply not released.
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: "Tag to derive from (e.g. 2.21.5-beta38)"
+        required: true
+
+permissions:
+  contents: write # for pushing tags and creating releases
+
+jobs:
+  release-jackson-lines:
+    strategy:
+      # A line that fails to build must not take the others down with it.
+      fail-fast: false
+      matrix:
+        # Jackson minor lines to release for.
+        jackson-line: [ '2.21', '2.22' ]
+    name: "Jackson ${{ matrix.jackson-line }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Plan
+        id: plan
+        env:
+          BASE_TAG: ${{ inputs.base_tag || github.event.release.tag_name }}
+          LINE: ${{ matrix.jackson-line }}
+        run: |
+          set -euo pipefail
+          # 2.21.5-beta38 -> beta38
+          suffix="${BASE_TAG#*-}"
+          esc="${LINE//./\\.}"
+          latest=$(curl -fsSL https://repo1.maven.org/maven2/com/fasterxml/jackson/jackson-bom/maven-metadata.xml \
+            | grep -oE "<version>${esc}\.[0-9]+</version>" | grep -oE '[0-9]+(\.[0-9]+)*' | sort -V | tail -n1)
+          [ -n "$latest" ] || { echo "::error::No release found for the Jackson ${LINE} line"; exit 1; }
+          version="${latest}-${suffix}"
+          echo "base_tag=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "jackson=$latest" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # Skips the base tag itself, re-runs, and recursion from the releases created below.
+          if git ls-remote --exit-code --tags \
+               "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/$version" > /dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$version already exists, skipping"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.plan.outputs.skip == 'false'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.plan.outputs.base_tag }}
+      - name: Set up java
+        if: steps.plan.outputs.skip == 'false'
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+      - name: Setup Gradle
+        if: steps.plan.outputs.skip == 'false'
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Rewrite the Jackson version
+        if: steps.plan.outputs.skip == 'false'
+        env:
+          JACKSON: ${{ steps.plan.outputs.jackson }}
+          VERSION: ${{ steps.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i -E "s|^jackson = \".*\"|jackson = \"${JACKSON}\"|" gradle/libs.versions.toml
+          # JitPack resolves artifacts by tag name, so the Gradle version must match it.
+          # This also verifies that the rewrite above took effect.
+          actual=$(./gradlew -q properties | sed -n 's/^version: //p')
+          if [ "$actual" != "$VERSION" ]; then
+            echo "::error::Gradle version ($actual) does not match the tag ($VERSION)"; exit 1
+          fi
+
+      - name: Lint
+        if: steps.plan.outputs.skip == 'false'
+        run: ./gradlew lintKotlin
+      - name: Test
+        if: steps.plan.outputs.skip == 'false'
+        run: ./gradlew test
+      - name: Publish Test Report
+        if: always() && steps.plan.outputs.skip == 'false'
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      - name: Tag and release
+        if: steps.plan.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_URL: ${{ github.server_url }}/${{ github.repository }}
+          BASE_TAG: ${{ steps.plan.outputs.base_tag }}
+          JACKSON: ${{ steps.plan.outputs.jackson }}
+          VERSION: ${{ steps.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # No commit is needed when the base tag already points at the target version.
+          if ! git diff --quiet; then
+            git commit -am "Build $VERSION against Jackson $JACKSON"
+          fi
+          git tag "$VERSION"
+          git push origin "refs/tags/$VERSION"
+          gh release create "$VERSION" --title "$VERSION" \
+            --notes "Build for \`Jackson $JACKSON\`. The source is identical to [$BASE_TAG](${BASE_URL}/releases/tag/$BASE_TAG)."
+
+      # A release created with GITHUB_TOKEN does not trigger warmup-jitpack.yml,
+      # so the shared action is run here instead.
+      - name: Warm up JitPack
+        if: steps.plan.outputs.skip == 'false'
+        uses: ./.github/actions/warmup-jitpack
+        with:
+          tag: ${{ steps.plan.outputs.version }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,8 +4,9 @@ dependencyResolutionManagement {
     versionCatalogs {
         // gradle/libs.versions.toml is imported automatically, so only the overrides are declared here.
         create("libs") {
-            // Mainly for CI, it can be rewritten by environment variable.
+            // Mainly for CI, they can be rewritten by environment variables.
             System.getenv("KOTLIN_VERSION")?.takeIf { it.isNotEmpty() }?.let { version("kotlin", it) }
+            System.getenv("JACKSON_VERSION")?.takeIf { it.isNotEmpty() }?.let { version("jackson", it) }
         }
     }
 }


### PR DESCRIPTION
## Problem

Jackson 2.x currently maintains two LTS lines, 2.21 and 2.22. This project is based on 2.21, so a release only ever covers that line.

## Approach

The version scheme already encodes the Jackson version (`<jackson version>-beta<N>`), so the two lines never collide: `2.21.5-beta38` and `2.22.1-beta38` are distinct coordinates, and the shared beta number shows at a glance that they are built from identical source.

JitPack builds a git tag, so the tag itself has to carry the right Jackson version. On every published release, the workflow creates a commit on top of the released tag that rewrites only the `jackson` line of the version catalog, and tags it for the other line. No branch is maintained; the derived commit is reachable from its tag and its parent is the released tag, so it stays traceable.

```
main ──● 2.21.5-beta38   (published manually, as today)
        └──● 2.22.1-beta38   (derived automatically)
```

Per line, the job:

1. Resolves the latest patch of that line from Maven Central, and derives `<latest patch>-<same beta number>`.
2. Skips if that tag already exists. This covers the released tag itself, re-runs, and any recursion.
3. Checks out the released tag and rewrites `gradle/libs.versions.toml`.
4. Verifies that the resulting Gradle version equals the tag. JitPack resolves artifacts by tag name, so a mismatch would publish nothing usable.
5. Runs lint and test.
6. Commits, tags, pushes, creates the release, and builds it on JitPack.

**The tag is pushed only after lint and test pass**, so a line that is incompatible with the current source is simply not released. `fail-fast: false` keeps one line from taking the others down. In practice only the 2.22 job does work, since 2.21 skips on the existing tag.

Adding or dropping a line is a single edit to the matrix.

## About the JACKSON_VERSION override

`settings.gradle.kts` gains a `JACKSON_VERSION` override, mirroring the existing `KOTLIN_VERSION` one. CI does not use it — the release path has to rewrite the catalog, because JitPack builds the tag content and no environment variable reaches it.

It is there so that a failure reported by this workflow can be reproduced locally with `JACKSON_VERSION=2.22.1 ./gradlew test`, without editing the catalog. Since there is no pre-release check, that reproduction path is the only thing standing between a red release run and hand-editing files. Drop it if that does not seem worth an unused-by-CI mechanism.

## Verification

Confirmed locally:

| Check | Result |
|---|---|
| `./gradlew test` against Jackson 2.22.1 | BUILD SUCCESSFUL — the current source is compatible with both lines |
| Resolution under 2.22.1 | `jackson-databind 2.22.1`, `jackson-annotations 2.22` — correct, since annotations has no patch component and must come from the BOM |
| Plan step shell, run as written | `2.21 -> 2.21.5-beta38` (skipped, tag exists), `2.22 -> 2.22.1-beta38` |
| Rewrite step, run against the real catalog | Gradle version becomes `2.22.1-beta38` and matches the tag |
| `JACKSON_VERSION=2.22.1 ./gradlew properties` | `2.22.1-beta38` |

The workflow itself has not run on GitHub yet. `workflow_dispatch` takes a tag, so it can be exercised against an existing release without cutting a new one.

## Trade-off

There is no pre-release check against 2.22, so an incompatibility surfaces when the release runs rather than before. The 2.21 release is unaffected, but the decision of whether to fix 2.22 or skip it lands in the middle of the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
