### PR TITLE
Wait for JitPack to notice a freshly pushed tag

### DIFF
--- a/.github/actions/warmup-jitpack/action.yml
+++ b/.github/actions/warmup-jitpack/action.yml
@@ -5,6 +5,14 @@ inputs:
   tag:
     description: "Tag to build on JitPack (e.g. 2.21.5-beta38)"
     required: true
+  attempts:
+    description: "How many times to ask JitPack before giving up on the tag"
+    required: false
+    default: '10'
+  interval:
+    description: "Seconds to wait between those attempts"
+    required: false
+    default: '60'
 
 runs:
   using: composite
@@ -12,11 +20,32 @@ runs:
     - shell: bash
       env:
         TAG: ${{ inputs.tag }}
+        ATTEMPTS: ${{ inputs.attempts }}
+        INTERVAL: ${{ inputs.interval }}
       run: |
         set -euo pipefail
         base="https://jitpack.io/com/github/${GITHUB_REPOSITORY}/${TAG}"
+        log=$(mktemp)
         # JitPack builds on demand. Requesting the log starts the build and streams its output,
         # so that the first consumer of a new version does not have to wait for it.
-        curl -fsSL --max-time 900 "${base}/build.log" | tail -n 50
+        #
+        # JitPack answers with 404 while the tag is missing from the ref list it caches from
+        # GitHub, which is the normal state for a tag that was pushed moments ago, so that answer
+        # is waited out. The status has to be read from the response instead of relying on
+        # curl --fail, because it does not tell 404 apart from a timeout or a 5xx.
+        for attempt in $(seq 1 "$ATTEMPTS"); do
+          code=$(curl -sSL --max-time 900 -o "$log" -w '%{http_code}' "${base}/build.log") || code=000
+          case "$code" in
+            2??) break ;;
+            404 | 5?? | 000)
+              if [ "$attempt" -eq "$ATTEMPTS" ]; then
+                echo "::error::JitPack did not pick up ${TAG} (last status ${code})"; exit 1
+              fi
+              echo "::notice::JitPack does not know ${TAG} yet (${code}), retrying in ${INTERVAL}s (${attempt}/${ATTEMPTS})"
+              sleep "$INTERVAL" ;;
+            *) echo "::error::Requesting the JitPack build log failed with ${code}"; exit 1 ;;
+          esac
+        done
+        tail -n 50 "$log"
         # The log alone does not reliably report the result, so the artifact itself is requested.
         curl -fsS --max-time 60 -o /dev/null "${base}/${GITHUB_REPOSITORY#*/}-${TAG}.pom"

--- a/.github/workflows/release-jackson-lines.yml
+++ b/.github/workflows/release-jackson-lines.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write # for pushing tags and creating releases
+  checks: write # for action-junit-report
 
 jobs:
   release-jackson-lines:
@@ -28,7 +29,7 @@ jobs:
         jackson-line: [ '2.21', '2.22' ]
     name: "Jackson ${{ matrix.jackson-line }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Plan
         id: plan

--- a/.github/workflows/warmup-jitpack.yml
+++ b/.github/workflows/warmup-jitpack.yml
@@ -21,7 +21,7 @@ jobs:
   warmup-jitpack:
     name: warmup-jitpack
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

The first run of `release-jackson-lines` failed on `Warm up JitPack` ([run 32472618001](https://github.com/ProjectMapK/jackson-module-kogera/actions/runs/32472618001/job/96742387657)). The release itself was fine — tag, GitHub release and, in the end, the JitPack build all succeeded. Only the warm-up step was wrong, and it was wrong deterministically.

```
10:27:54.184  git push origin refs/tags/2.22.2-beta38
10:27:55.035  Warm up JitPack starts
10:27:55.114  curl: (22) The requested URL returned error: 404   ← 0.85s after the push
```

JitPack serves the ref list it caches from GitHub, and answers `404` for anything missing from it. Its own record shows the request landing in exactly that window:

```json
{ "version": "2.22.2-beta38", "status": "tagNotFound",
  "message": "Tag or commit not found: 2.22.2-beta38",
  "time": 1787308075104 }   // 2026-08-21T10:27:55Z, the second the step ran
```

This is not a race that happens to be lost sometimes. The sibling `warmup-jitpack` run for the same release ([32472617772](https://github.com/ProjectMapK/jackson-module-kogera/actions/runs/32472617772)) had queried JitPack at 10:26–10:27 and warmed that cache with a ref list that could not contain a tag pushed at 10:27:54. Every new line released this way walks into it.

The cache expired on its own a few minutes later, the build ran, and `2.22.2-beta38` resolves normally today:

```json
{ "version": "2.22.2-beta38", "status": "ok",
  "commit": "389a9ce42099d15b5cf42a0eb0ba501930004d0b", "isTag": true }
```

## Approach

Waiting a fixed amount of time before the first request does not fix this — the stale cache predates the push, so the entry has to expire regardless. The warm-up retries the `404` instead.

`curl --fail` is dropped in favour of reading `%{http_code}`, because it collapses `404`, a timeout and a `5xx` into the same exit code 22 and the step cannot tell "the tag is not visible yet" from "JitPack is broken". With the status in hand:

- `2xx` — the build started, stream the log as before.
- `404`, `5xx`, or a transport failure — wait and ask again, up to `attempts` times (default 10 × 60s).
- anything else — fail immediately.

The retry lives in the composite action, so `warmup-jitpack.yml` gets it too; a release published for an existing tag happens to survive today only because the runner boot and checkout give JitPack a head start.

`timeout-minutes` goes to 30 on both jobs, since the retries can now add up to 10 minutes on top of a JitPack build that took 5m32s in the run above.

## Also here

`release-jackson-lines.yml` declares only `contents: write`, so `mikepenz/action-junit-report` could not create its check run:

> ❌ Failed to create checks using the provided token. (HttpError: Resource not accessible by integration)

`checks: write` is added, matching `lint-and-test-dev.yml` and `test-main.yml`.

## Verification

The script was run against JitPack outside CI:

- an unknown tag retries and then fails with `::error::JitPack did not pick up 9.9.9-nope (last status 404)`
- `2.22.2-beta38` streams the log and the `.pom` request returns 200

All three YAML files parse.

The retry path against a tag pushed seconds earlier can only really be exercised by the next release.
